### PR TITLE
feat(vscode-e2e): pilot scenarios-pilot shard (Phase B)

### DIFF
--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -57,6 +57,8 @@ jobs:
             e2e_mode: createplusnewtests
           - shard: conversion
             e2e_mode: createplusconversion
+          - shard: scenarios-pilot
+            e2e_mode: scenarios-pilot
 
     steps:
       - name: Checkout

--- a/apps/vs-code-designer/src/test/ui/run-e2e.js
+++ b/apps/vs-code-designer/src/test/ui/run-e2e.js
@@ -1523,6 +1523,32 @@ namespace ${namespaceName}
       process.exit(scenariosExit);
     }
 
+    if (e2eMode === 'scenarios-pilot') {
+      await extest.downloadCode(VSCODE_VERSION);
+      await extest.downloadChromeDriver(VSCODE_VERSION);
+      // Pilot exactly one scenario: inlineJavascript. Decision gate per the
+      // per-scenario re-architecture plan — if this passes where the current
+      // createplusnewtests shard fails Phase 4.3, the new pattern is validated.
+      const pilotScenarios = scenarios.filter((s) => s.id === 'p43-inlinejavascript');
+      if (pilotScenarios.length === 0) {
+        throw new Error('scenarios-pilot: p43-inlinejavascript scenario not found in scenarios[] table');
+      }
+      // Phase 4.1 must run first to populate the manifest the bootstrapper consumes
+      // for { appType: 'standard', wfType: 'Stateful' }. Mirror createplusnewtests's
+      // Phase 4.1 invocation.
+      writeTestSettings({ validateDependencies: true, autoStartDesignTime: true });
+      await prepareFreshSession('phase1-pilot');
+      const phase1Exit = await runPhase('Phase 4.1: createWorkspace (pilot prerequisite)', phase1Files);
+      if (phase1Exit !== 0) {
+        console.log(`\n⚠ Phase 4.1 exited with code ${phase1Exit} — pilot cannot proceed without manifest`);
+        process.exit(phase1Exit);
+      }
+      // Now run the pilot scenario through the bootstrapper.
+      const pilotExit = await runScenarioPhases(pilotScenarios);
+      console.log(`\n=== Pilot result: 4.1=${phase1Exit}, p43-inlinejavascript=${pilotExit} → exit ${Math.max(phase1Exit, pilotExit)} ===`);
+      process.exit(Math.max(phase1Exit, pilotExit));
+    }
+
     if (e2eMode === 'codefuldebugonly') {
       await extest.downloadCode(VSCODE_VERSION);
       await extest.downloadChromeDriver(VSCODE_VERSION);


### PR DESCRIPTION
## Phase B — Per-scenario E2E pilot

Pilots the per-scenario bootstrapper (added in Phase A, `cf2406281`) by running ONLY the `inlineJavascript` scenario through it.

### What this PR adds
- `run-e2e.js`: new `E2E_MODE=scenarios-pilot` handler that
  1. Runs Phase 4.1 `createWorkspace` to populate the workspace manifest, then
  2. Filters `scenarios[]` to `p43-inlinejavascript` and runs it through `runScenarioPhases()`.
- `.github/workflows/vscode-e2e.yml`: 5th matrix shard `scenarios-pilot` running side-by-side with the existing 4 (`independent`, `designer`, `newtests`, `conversion`).

### Decision gate
The existing `newtests` shard runs Phase 4.3 the OLD way (sequential after 4.1 with `prepareFreshSession` between).
The new `scenarios-pilot` shard runs the same Phase 4.3 through the NEW bootstrapper.
Same input, different orchestration.

- **If `scenarios-pilot` passes where `newtests` fails Phase 4.3** → architecture validated, proceed to Phase C (migrate remaining scenarios).
- **If both fail identically** → architecture alone doesn't fix the runner-image cold-start regression; don't migrate.

### Validation
- `node --check apps/vs-code-designer/src/test/ui/run-e2e.js` — passes.
- `pnpm exec tsup --config apps/vs-code-designer/tsup.e2e.test.config.ts` — passes (no .ts changes, but full build green).
- `pnpm exec biome check` on touched files — clean.

### Scope
Existing 4 shards remain unchanged. `vscode-e2e-summary` `needs: vscode-e2e` naturally picks up the new shard — no branch-protection edits required.

Draft until the pilot CI run completes and the decision gate fires.
