### PR TITLE
test(vscode-e2e): harden workspaceConversionYes with R1-R9 + real assertions

### DIFF
--- a/apps/vs-code-designer/src/test/ui/helpers.ts
+++ b/apps/vs-code-designer/src/test/ui/helpers.ts
@@ -13,7 +13,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
-import { By, Key, ModalDialog, type WebDriver } from 'vscode-extension-tester';
+import { By, Key, ModalDialog, until, type WebDriver } from 'vscode-extension-tester';
 
 type WebDriverElement = Awaited<ReturnType<WebDriver['findElements']>>[number];
 
@@ -327,6 +327,186 @@ export async function dismissAllDialogs(driver: WebDriver): Promise<boolean> {
   }
 
   return false;
+}
+
+// ===========================================================================
+// Modal-dialog click helpers (used by workspace conversion tests)
+// ===========================================================================
+
+/**
+ * Returns true if a Selenium error indicates the WebDriver session has ended
+ * (e.g. VS Code reloaded, killing chromedriver). This is expected on the
+ * workspace-conversion "Yes" path where clicking the button reloads the
+ * window and tears down the Selenium session.
+ */
+export function isSessionEnded(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e);
+  return /invalid session id|NoSuchSession|session deleted|chrome not reachable|target window already closed|disconnected: not connected/i.test(
+    msg
+  );
+}
+
+/**
+ * Force-focus the primary button of the active modal dialog. xvfb does not
+ * auto-raise modal windows, so the focused element on the underlying editor
+ * can swallow click events directed at the dialog. Calling .focus() via JS
+ * on the modal's primary button bypasses this and ensures Tab+Enter / click
+ * targets the dialog.
+ */
+export async function focusModalPrimaryButton(driver: WebDriver): Promise<boolean> {
+  try {
+    const focused = await driver.executeScript<boolean>(`
+      const btn = document.querySelector('.monaco-dialog-box button.primary, .monaco-dialog-box button');
+      if (btn) { btn.focus(); return true; }
+      return false;
+    `);
+    return focused === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Capture diagnostic information about modal dialogs / notifications / the
+ * active element to disk. Used as a fallback when clicking a dialog button
+ * fails so CI artifacts contain enough context to root-cause the failure.
+ */
+export async function dumpDialogDiagnostics(driver: WebDriver, label: string, dir: string): Promise<void> {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const lines: string[] = [`[${ts}] ${label}`];
+  try {
+    lines.push(`title: ${await driver.getTitle()}`);
+    lines.push(`url: ${await driver.getCurrentUrl()}`);
+    const bodyLen = await driver.executeScript('return document.body.outerHTML.length');
+    lines.push(`bodyHtmlLen: ${bodyLen}`);
+    const dialogs = await driver.findElements(By.css('.monaco-dialog-box'));
+    lines.push(`dialogCount: ${dialogs.length}`);
+    for (let i = 0; i < dialogs.length; i++) {
+      const txt = (await dialogs[i].getText().catch(() => '')).slice(0, 200);
+      lines.push(`dialog[${i}]: ${txt}`);
+    }
+    const toasts = await driver.findElements(By.css('.notification-toast'));
+    lines.push(`notificationCount: ${toasts.length}`);
+    const active = await driver.switchTo().activeElement();
+    const tag = await active.getTagName().catch(() => '?');
+    const cls = await active.getAttribute('class').catch(() => '?');
+    lines.push(`activeElement: <${tag} class="${cls}">`);
+  } catch (e) {
+    lines.push(`(diagnostic capture errored: ${e instanceof Error ? e.message : String(e)})`);
+  }
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${sanitizeFileSegment(label)}-${ts}.txt`), lines.join('\n'));
+  } catch (e) {
+    console.log(`[dumpDialogDiagnostics] failed to write: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+/**
+ * Resolve a single ModalDialog handle and click the named button, retrying
+ * on StaleElementReferenceError. Two prior bugs in workspaceConversionYes
+ * were caused by (a) instantiating two `new ModalDialog()` references and
+ * having the second go stale, and (b) the first click silently failing
+ * because xvfb hadn't routed focus to the dialog yet.
+ *
+ * The retry path force-focuses the primary button before re-attempting,
+ * waits for it to be visible, and finally falls back to Tab+Enter — which
+ * is the most xvfb-robust way to activate the default modal button.
+ */
+export async function pushDialogButtonWithRetry(driver: WebDriver, label: string, retries = 3, diagnosticsDir?: string): Promise<void> {
+  let lastErr: Error | undefined;
+  for (let i = 0; i < retries; i++) {
+    try {
+      const dialog = new ModalDialog();
+      // AbstractElement.wait() exists on older versions; guard with optional chain.
+      try {
+        await (dialog as unknown as { wait?: (timeout: number) => Promise<void> }).wait?.(5000);
+      } catch {
+        /* ignore — pushButton will throw the real error if dialog is missing */
+      }
+      // Force focus + wait for visibility BEFORE click — xvfb sometimes leaves
+      // focus on the underlying editor, which swallows the click.
+      await focusModalPrimaryButton(driver);
+      await sleep(200);
+      try {
+        const btn = await driver.findElement(By.css('.monaco-dialog-box button.primary, .monaco-dialog-box button'));
+        await driver.wait(until.elementIsVisible(btn), 5000).catch(() => undefined);
+      } catch {
+        /* dialog may have closed already */
+      }
+      await dialog.pushButton(label);
+      console.log(`[pushDialogButtonWithRetry] Clicked "${label}" (attempt ${i + 1})`);
+      return;
+    } catch (e) {
+      lastErr = e as Error;
+      const msg = e instanceof Error ? e.message : String(e);
+      console.log(`[pushDialogButtonWithRetry] attempt ${i + 1} failed: ${msg.substring(0, 200)}`);
+      if (isSessionEnded(e)) {
+        // Session is gone — the click probably worked and VS Code reloaded.
+        throw e;
+      }
+      if (diagnosticsDir) {
+        await dumpDialogDiagnostics(driver, `pushDialogButton-attempt${i + 1}`, diagnosticsDir);
+      }
+      if ((i < retries - 1 && e instanceof Error && e.name === 'StaleElementReferenceError') || /stale|detached/i.test(msg)) {
+        await sleep(500);
+        continue;
+      }
+      // Final fallback on the last attempt: Tab+Enter — xvfb-robust default-button activation.
+      if (i === retries - 1) {
+        try {
+          await focusModalPrimaryButton(driver);
+          await sleep(200);
+          await driver.actions().sendKeys(Key.TAB).perform();
+          await sleep(150);
+          await driver.actions().sendKeys(Key.ENTER).perform();
+          console.log('[pushDialogButtonWithRetry] Fell back to Tab+Enter');
+          return;
+        } catch (fallbackErr) {
+          if (isSessionEnded(fallbackErr)) {
+            throw fallbackErr;
+          }
+          lastErr = fallbackErr as Error;
+        }
+      }
+      await sleep(500);
+    }
+  }
+  throw lastErr ?? new Error(`Failed to push '${label}' after ${retries} retries`);
+}
+
+/**
+ * Cancel any currently open VS Code quick-input widget (command palette,
+ * quick-pick, input box). Pressing Escape is safe even if no widget is
+ * showing — this is a defensive pre-flight before opening a new prompt.
+ */
+export async function safeCancelAnyQuickInput(driver: WebDriver): Promise<void> {
+  try {
+    const visible = await driver.executeScript<boolean>(`
+      const w = document.querySelector('.quick-input-widget:not(.hidden)');
+      return !!(w && w.offsetHeight > 0);
+    `);
+    if (!visible) {
+      return;
+    }
+    for (let i = 0; i < 3; i++) {
+      try {
+        await driver.actions().sendKeys(Key.ESCAPE).perform();
+      } catch {
+        /* ignore */
+      }
+      await sleep(200);
+      const stillVisible = await driver.executeScript<boolean>(`
+        const w = document.querySelector('.quick-input-widget:not(.hidden)');
+        return !!(w && w.offsetHeight > 0);
+      `);
+      if (!stillVisible) {
+        return;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
 }
 
 /**

--- a/apps/vs-code-designer/src/test/ui/run-e2e.js
+++ b/apps/vs-code-designer/src/test/ui/run-e2e.js
@@ -789,6 +789,22 @@ async function main() {
     console.log(`  DOTNET_ROOT: ${dotnetSdkDir}`);
   }
 
+  // R4 (workspaceConversionYes hardening): lock VS Code's host locale to
+  // en-US so localized button labels (DialogResponses.yes.title === 'Yes',
+  // 'No', 'Cancel', etc.) stay stable across CI runners. Without this,
+  // Linux runners can default to C.UTF-8 / German / Japanese and the
+  // ExTester ModalDialog.pushButton('Yes') call mis-matches.
+  if (!process.env.LANG) {
+    process.env.LANG = 'en_US.UTF-8';
+  }
+  if (!process.env.LC_ALL) {
+    process.env.LC_ALL = 'en_US.UTF-8';
+  }
+  if (!process.env.VSCODE_NLS_CONFIG) {
+    process.env.VSCODE_NLS_CONFIG = JSON.stringify({ locale: 'en-us', availableLanguages: {} });
+  }
+  console.log(`  Locale lock: LANG=${process.env.LANG} LC_ALL=${process.env.LC_ALL}`);
+
   const outTestDir = path.resolve(projectDir, 'out', 'test');
   const testFile = (name) => path.join(outTestDir, name).replace(/\\/g, '/');
 

--- a/apps/vs-code-designer/src/test/ui/workspaceConversionYes.test.ts
+++ b/apps/vs-code-designer/src/test/ui/workspaceConversionYes.test.ts
@@ -7,28 +7,67 @@
  * ADO Coverage: Test Case #31054994, Steps 5-7
  *
  * Verifies:
- *   1. Opening a workspace DIRECTORY (not .code-workspace file) triggers
- *      the "You must open your workspace..." prompt
- *   2. Clicking "Yes" is successful (the button is clickable)
+ *   1. Pre-click filesystem invariants (A1-A7): .code-workspace, host.json,
+ *      launch.json with a logic-app debug configuration, tasks.json with
+ *      a "func: host start" task, workflow.json all exist & parse.
+ *   2. The convertToWorkspace prompt is shown as a **modal** dialog
+ *      (convertToWorkspace.ts:119-121 — `{ modal: true }`), so detection
+ *      uses ExTester's ModalDialog only. No notification fallback.
+ *   3. Clicking the localized "Yes" button (en-US locale locked via run-e2e.js;
+ *      label matches `DialogResponses.yes.title` from `@microsoft/vscode-azext-utils`)
+ *      either reloads the window (session ends or title flips to
+ *      "(Workspace)") or, if reload is deferred, returns successfully.
+ *   4. Post-reload (when session survives): no extension-error.log,
+ *      .code-workspace mtime did not regress, A1-A7 still hold, no
+ *      .code-workspace text editor is open, Azure activity-bar item is
+ *      present, no error notifications.
  *
- * NOTE: Clicking "Yes" causes VS Code to reload (opens the .code-workspace),
- * which terminates the Selenium session. We can verify the dialog appeared
- * and the button click succeeded, but cannot verify the post-reload state.
- * The actual reload behavior is covered by CLI integration tests in
- * workspaceConversion.test.ts.
+ * Phase 4.8d — own session, startup resource = workspace directory.
  *
- * Phase 4.8d — own session, startup resource = workspace directory
+ * Hardening applied (R1-R9 — Track 3 of the e2e-optimizations effort):
+ *   R1 drop notification-scanning (prompt is modal)
+ *   R2 single ModalDialog handle with stale-element retry
+ *   R3 force-focus + Tab+Enter fallback for xvfb-robust click
+ *   R4 locale-lock via en-US LANG/LC_ALL (label matches DialogResponses.yes.title)
+ *   R5 safeCancelAnyQuickInput pre-flight cleanup
+ *   R6 elementIsVisible wait before click (inside pushDialogButtonWithRetry)
+ *   R7 timeout bumps: phase 60s -> 120s, prompt 30s -> 45s
+ *   R8 dumpDialogDiagnostics on click failure
+ *   R9 milestone screenshots
+ *
+ * NOTE: `allowFailure: true` remains at run-e2e.js:932 pending 3 consecutive
+ * green CI runs (R10 gate). Do not remove until validated.
  */
 
 import * as path from 'path';
 import * as fs from 'fs';
 import * as assert from 'assert';
-import { type WebDriver, VSBrowser, ModalDialog, By, Key } from 'vscode-extension-tester';
+import { type WebDriver, VSBrowser, ModalDialog, By, EditorView, Workbench, NotificationType } from 'vscode-extension-tester';
 import { WORKSPACE_MANIFEST_PATH, loadWorkspaceManifest } from './workspaceManifest';
 import type { WorkspaceManifestEntry } from './workspaceManifest';
-import { sleep, captureScreenshot, openFolderInSession } from './helpers';
+import {
+  sleep,
+  captureScreenshot,
+  openFolderInSession,
+  pushDialogButtonWithRetry,
+  isSessionEnded,
+  safeCancelAnyQuickInput,
+  dumpDialogDiagnostics,
+} from './helpers';
 
-const TEST_TIMEOUT = 60_000;
+const TEST_TIMEOUT = 120_000;
+const PROMPT_DEADLINE_MS = 45_000;
+const RELOAD_DEADLINE_MS = 30_000;
+
+/**
+ * Localized title of `DialogResponses.yes` from `@microsoft/vscode-azext-utils`
+ * (defined as `vscode_1.l10n.t('Yes')`). We cannot import DialogResponses
+ * directly because that module does `require('vscode')` at load time, and
+ * ExTester runs Mocha as a separate process where the `vscode` module is not
+ * available. R4 locks the CI runner locale to en-US via LANG/LC_ALL in
+ * run-e2e.js so this literal is stable across runs.
+ */
+const YES_BUTTON_LABEL = 'Yes';
 
 const EXPLICIT_SCREENSHOT_DIR = path.join(
   process.env.TEMP || process.cwd(),
@@ -38,40 +77,105 @@ const EXPLICIT_SCREENSHOT_DIR = path.join(
   new Date().toISOString().replace(/[:.]/g, '-')
 );
 
+const DIAGNOSTICS_DIR = path.join(EXPLICIT_SCREENSHOT_DIR, 'diagnostics');
+
+/** Strip a UTF-8 BOM that VS Code sometimes writes on Windows. */
+function readJsonFile<T = unknown>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/, '')) as T;
+}
+
 /**
- * Wait for the workspace prompt (notification or modal dialog).
- * Returns the message text, or null if not found.
+ * Wait for the convertToWorkspace modal dialog. The prompt is created with
+ * `{ modal: true }` (convertToWorkspace.ts:119-121), so we only ever look at
+ * ExTester's ModalDialog page object. Returns the message text or null.
  */
-async function waitForWorkspacePrompt(driver: WebDriver, timeoutMs = 30_000): Promise<string | null> {
+async function waitForWorkspacePrompt(driver: WebDriver, timeoutMs: number): Promise<string | null> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    // Check ModalDialog
     try {
       const dialog = new ModalDialog();
       const message = await dialog.getMessage();
-      if (message && (message.includes('workspace') || message.includes('Workspace'))) {
+      if (message && /workspace/i.test(message)) {
         console.log(`[conversionYes] Found modal dialog: "${message.substring(0, 150)}"`);
         return message;
       }
     } catch {
-      // No modal dialog
-    }
-    // Check notification/raw dialog
-    try {
-      const dialogs = await driver.findElements(By.css('.monaco-dialog-box, [role="dialog"], .notification-toast'));
-      for (const d of dialogs) {
-        const text = await d.getText().catch(() => '');
-        if (text.includes('workspace') || text.includes('Workspace') || text.includes('Open Workspace')) {
-          console.log(`[conversionYes] Found prompt: "${text.substring(0, 150)}"`);
-          return text;
-        }
-      }
-    } catch {
-      // No dialog elements
+      /* no modal yet */
     }
     await sleep(1000);
   }
+  // On timeout, dump diagnostics so CI artifacts contain the DOM snapshot.
+  await dumpDialogDiagnostics(driver, 'waitForWorkspacePrompt-timeout', DIAGNOSTICS_DIR);
   return null;
+}
+
+/** Detect whether VS Code reloaded the workbench after pushing "Yes". */
+async function waitForReloadOrTitleChange(
+  driver: WebDriver,
+  titleBefore: string | null,
+  timeoutMs: number
+): Promise<{ kind: 'session-ended' | 'title-changed' | 'url-changed' | 'none' }> {
+  const deadline = Date.now() + timeoutMs;
+  const urlBefore = await driver.getCurrentUrl().catch(() => null);
+  while (Date.now() < deadline) {
+    try {
+      const titleNow = await driver.getTitle();
+      if (titleBefore && !titleBefore.includes('(Workspace)') && titleNow.includes('(Workspace)')) {
+        return { kind: 'title-changed' };
+      }
+      const urlNow = await driver.getCurrentUrl();
+      if (urlBefore && urlNow !== urlBefore) {
+        return { kind: 'url-changed' };
+      }
+    } catch (e) {
+      if (isSessionEnded(e)) {
+        return { kind: 'session-ended' };
+      }
+      throw e;
+    }
+    await sleep(1000);
+  }
+  return { kind: 'none' };
+}
+
+/** Validate filesystem invariants A1-A7 for a manifest entry. */
+function assertWorkspaceFsInvariants(entry: WorkspaceManifestEntry, phase: string): void {
+  // A1: .code-workspace exists.
+  assert.ok(fs.existsSync(entry.wsFilePath), `[${phase}] .code-workspace must exist at ${entry.wsFilePath}`);
+
+  // A2: parses as JSON with folders[].
+  const ws = readJsonFile<{ folders?: Array<{ path: string }> }>(entry.wsFilePath);
+  assert.ok(Array.isArray(ws.folders) && ws.folders.length >= 1, `[${phase}] .code-workspace must list folders[]`);
+
+  // A3: folder path resolves to appDir.
+  const wsDir = path.dirname(entry.wsFilePath);
+  const matchesAppDir = (ws.folders ?? []).some((f) => path.resolve(wsDir, f.path) === path.resolve(entry.appDir));
+  assert.ok(matchesAppDir, `[${phase}] .code-workspace folders must include the logic app folder ${entry.appDir}`);
+
+  // A4: host.json.
+  assert.ok(fs.existsSync(path.join(entry.appDir, 'host.json')), `[${phase}] host.json must exist`);
+
+  // A5: launch.json with a logic-app debug configuration.
+  const launchPath = path.join(entry.appDir, '.vscode', 'launch.json');
+  assert.ok(fs.existsSync(launchPath), `[${phase}] launch.json must exist at ${launchPath}`);
+  const launch = readJsonFile<{ configurations?: Array<{ type?: string }> }>(launchPath);
+  assert.ok(
+    Array.isArray(launch.configurations) &&
+      launch.configurations.some((c) => typeof c.type === 'string' && /logicapp|pwa-node|coreclr/i.test(c.type)),
+    `[${phase}] launch.json must include a logic-app debug configuration (logicapp/pwa-node/coreclr)`
+  );
+
+  // A6: tasks.json with "func: host start".
+  const tasksPath = path.join(entry.appDir, '.vscode', 'tasks.json');
+  assert.ok(fs.existsSync(tasksPath), `[${phase}] tasks.json must exist at ${tasksPath}`);
+  const tasks = readJsonFile<{ tasks?: Array<{ label?: string }> }>(tasksPath);
+  assert.ok(
+    Array.isArray(tasks.tasks) && tasks.tasks.some((t) => typeof t.label === 'string' && /func:\s*host start/i.test(t.label)),
+    `[${phase}] tasks.json must include a "func: host start" task`
+  );
+
+  // A7: workflow.json.
+  assert.ok(fs.existsSync(path.join(entry.wfDir, 'workflow.json')), `[${phase}] workflow.json must exist at ${entry.wfDir}`);
 }
 
 describe('Workspace Conversion — Click Yes', function () {
@@ -83,6 +187,7 @@ describe('Workspace Conversion — Click Yes', function () {
   before(async function () {
     this.timeout(30_000);
     fs.mkdirSync(EXPLICIT_SCREENSHOT_DIR, { recursive: true });
+    fs.mkdirSync(DIAGNOSTICS_DIR, { recursive: true });
     if (!fs.existsSync(WORKSPACE_MANIFEST_PATH)) {
       assert.fail(`Workspace manifest not found at ${WORKSPACE_MANIFEST_PATH} - Phase 4.1 must run first`);
       return;
@@ -96,185 +201,137 @@ describe('Workspace Conversion — Click Yes', function () {
   });
 
   it('should show workspace prompt and successfully click Yes', async () => {
-    // Open the workspace DIRECTORY via command palette to trigger conversion dialog.
-    // ExTester's startup resources use code -r which doesn't work on Linux CI.
     const entry = manifest.find((e) => e.appType === 'standard' && e.wfType === 'Stateful') || manifest[0];
     assert.ok(entry, 'No workspace entry found in manifest');
-    await openFolderInSession(driver, entry.wsDir);
 
+    // R9: milestone screenshot — test start.
     await captureScreenshot(driver, 'conversion-yes-start', EXPLICIT_SCREENSHOT_DIR);
 
-    // Wait for the prompt
-    const promptMessage = await waitForWorkspacePrompt(driver, 30_000);
+    // A1-A7: pre-click FS invariants. If these fail the test never had a
+    // chance — Phase 4.1 didn't produce a usable workspace.
+    assertWorkspaceFsInvariants(entry, 'pre-click');
+    const preWsMtime = fs.statSync(entry.wsFilePath).mtimeMs;
+
+    // R5: defensive pre-flight — make sure no leftover quick-input from an
+    // earlier phase eats our Ctrl+Shift+P keystrokes.
+    await safeCancelAnyQuickInput(driver);
+
+    await openFolderInSession(driver, entry.wsDir);
+
+    // Wait for the modal prompt to appear (R1: modal-only detection; R7: 45s).
+    const promptMessage = await waitForWorkspacePrompt(driver, PROMPT_DEADLINE_MS);
     await captureScreenshot(driver, 'conversion-yes-prompt-found', EXPLICIT_SCREENSHOT_DIR);
 
-    if (!promptMessage) {
-      console.log('[conversionYes] No workspace prompt appeared — skipping');
-      assert.fail('Test precondition not met - required setup failed');
-      return;
-    }
+    assert.ok(promptMessage, 'workspace conversion modal dialog must appear within 45s');
+    assert.ok(/workspace/i.test(promptMessage), `prompt should mention "workspace": "${promptMessage.substring(0, 150)}"`);
 
-    assert.ok(
-      promptMessage.includes('workspace') || promptMessage.includes('Workspace') || promptMessage.includes('Open Workspace'),
-      `Prompt should mention workspace: "${promptMessage.substring(0, 100)}"`
-    );
+    // Capture the pre-click title so we can detect "(Workspace)" flip after click.
+    const titleBefore = await driver.getTitle().catch(() => null);
 
-    // Click "Yes" / "Open Workspace" / accept button
-    let clicked = false;
+    // R9: milestone — about to focus + click.
+    await captureScreenshot(driver, 'conversion-yes-focus-applied', EXPLICIT_SCREENSHOT_DIR);
 
-    // Strategy 1: Notification action buttons
-    // VS Code shows workspace prompt as a notification with "Open Workspace" as the title.
-    // The action button may be hidden behind "more actions..." or may be the notification itself.
+    // R2 + R3 + R4 + R6: single retrying handle, force-focus + visibility wait
+    // + Tab+Enter fallback, using the locale-locked Yes label (see
+    // YES_BUTTON_LABEL constant) instead of scanning a fallback list.
+    let clickThrew: unknown;
     try {
-      // First try clicking the notification's primary action directly
-      const actionBtns = await driver.findElements(
-        By.css('.notification-toast .action-label, .notification-list-item .action-label, .notifications-list-container .action-label')
-      );
-      console.log(`[conversionYes] Found ${actionBtns.length} notification action button(s)`);
-      for (const btn of actionBtns) {
-        const text = (await btn.getText().catch(() => '')).toLowerCase();
-        const ariaLabel = ((await btn.getAttribute('aria-label')?.catch(() => '')) || '').toLowerCase();
-        console.log(`[conversionYes]   Action: text="${text}" aria="${ariaLabel}"`);
-        if (text.includes('open workspace') || ariaLabel.includes('open workspace')) {
-          await btn.click();
-          clicked = true;
-          console.log('[conversionYes] Clicked "Open Workspace" notification action');
-          break;
-        }
-        // Click "more actions..." to reveal hidden actions
-        if (ariaLabel.includes('more actions')) {
-          await btn.click();
-          await sleep(500);
-          // Look for the action in the expanded menu
-          const menuItems = await driver.findElements(By.css('.context-view .action-label, .monaco-menu .action-label'));
-          for (const mi of menuItems) {
-            const miText = (await mi.getText().catch(() => '')).toLowerCase();
-            if (miText.includes('open workspace') || miText.includes('open')) {
-              await mi.click();
-              clicked = true;
-              console.log(`[conversionYes] Clicked "${miText}" from more actions menu`);
-              break;
-            }
-          }
-          if (clicked) {
-            break;
-          }
-          await driver.actions().sendKeys(Key.ESCAPE).perform();
-        }
+      await pushDialogButtonWithRetry(driver, YES_BUTTON_LABEL, 3, DIAGNOSTICS_DIR);
+    } catch (e) {
+      clickThrew = e;
+      if (!isSessionEnded(e)) {
+        await dumpDialogDiagnostics(driver, 'conversion-yes-click-failed', DIAGNOSTICS_DIR);
+        throw e;
       }
-    } catch {
-      /* ignore */
+      // Session-ended during click = reload raced ahead of the click ACK. That's success.
+      console.log('[conversionYes] Selenium session ended during click — VS Code reloaded');
     }
 
-    // Strategy 1b: Click the notification body/title itself via JS
-    // VS Code's "Open Workspace" may use the notification title as the action.
-    if (!clicked) {
-      try {
-        const clickedNotif = await driver.executeScript<boolean>(`
-          var notifs = document.querySelectorAll(
-            '.notification-toast, .notification-list-item, .notifications-toasts .notification-list-item'
-          );
-          for (var i = 0; i < notifs.length; i++) {
-            var text = (notifs[i].textContent || '').toLowerCase();
-            if (text.includes('open workspace') || text.includes('workspace')) {
-              var msg = notifs[i].querySelector('.notification-list-item-message, .notification-message');
-              if (msg) { msg.click(); return true; }
-              var link = notifs[i].querySelector('a');
-              if (link) { link.click(); return true; }
-              notifs[i].click();
-              return true;
-            }
-          }
-          return false;
-        `);
-        if (clickedNotif) {
-          clicked = true;
-          console.log('[conversionYes] Clicked notification body/title via JS');
-        }
-      } catch {
-        /* ignore */
+    // R9: milestone — post-click (may fail if session already gone).
+    try {
+      await captureScreenshot(driver, 'conversion-yes-post-click', EXPLICIT_SCREENSHOT_DIR);
+    } catch (e) {
+      if (!isSessionEnded(e)) {
+        throw e;
       }
     }
 
-    // Strategy 2: ModalDialog
-    if (!clicked) {
+    // B1-B3: detect reload. If click threw session-ended we already know.
+    let reloaded: Awaited<ReturnType<typeof waitForReloadOrTitleChange>>;
+    if (clickThrew && isSessionEnded(clickThrew)) {
+      reloaded = { kind: 'session-ended' };
+    } else {
       try {
-        const dialog = new ModalDialog();
-        await dialog.pushButton('Yes');
-        clicked = true;
-        console.log('[conversionYes] Clicked "Yes" via ModalDialog');
-      } catch {
-        try {
-          const dialog2 = new ModalDialog();
-          for (const label of ['Open', 'Open Workspace', 'OK']) {
-            try {
-              await dialog2.pushButton(label);
-              clicked = true;
-              console.log(`[conversionYes] Clicked "${label}" via ModalDialog`);
-              break;
-            } catch {
-              /* try next */
-            }
-          }
-        } catch {
-          /* no ModalDialog */
+        reloaded = await waitForReloadOrTitleChange(driver, titleBefore, RELOAD_DEADLINE_MS);
+      } catch (e) {
+        if (isSessionEnded(e)) {
+          reloaded = { kind: 'session-ended' };
+        } else {
+          throw e;
         }
       }
     }
 
-    // Strategy 3: Raw button selectors (for notifications)
-    if (!clicked) {
+    console.log(`[conversionYes] reload detection result: ${reloaded.kind}`);
+    assert.ok(reloaded.kind !== 'none', 'window must reload, title must flip to "(Workspace)", or the Selenium session must end');
+
+    // ---- Post-click filesystem reassertions (C1-C3). FS is reachable in
+    // every reload-kind, even after session-ended, because Node fs is local.
+    // C1: no extension-error.log.
+    const errorLog = path.join(entry.wsDir, '.vscode', 'extension-error.log');
+    assert.ok(!fs.existsSync(errorLog), `no extension error log should be written (saw ${errorLog})`);
+    // C2: .code-workspace mtime must not regress.
+    assert.ok(fs.statSync(entry.wsFilePath).mtimeMs >= preWsMtime, '.code-workspace must not be rewritten with an older mtime');
+    // C3: A1-A7 still hold.
+    assertWorkspaceFsInvariants(entry, 'post-click');
+
+    // ---- D1-D3: UI state assertions, only when the session survived.
+    if (reloaded.kind === 'title-changed' || reloaded.kind === 'url-changed') {
       try {
-        const buttons = await driver.findElements(
-          By.css('.monaco-dialog-box button, [role="dialog"] button, .notification-toast button, .notification-toast .action-label')
+        // D1: no .code-workspace text editor open.
+        const titles = await new EditorView().getOpenEditorTitles().catch(() => [] as string[]);
+        assert.ok(!titles.some((t) => /\.code-workspace$/.test(t)), 'workspace should be opened as a workspace, not as a text editor');
+
+        // D2: Azure / Logic Apps activity-bar item present.
+        const activityIcons = await driver.findElements(
+          By.css('.activitybar .codicon[aria-label*="Azure"], .activitybar [aria-label*="Logic Apps"]')
         );
-        for (const btn of buttons) {
-          const text = (await btn.getText().catch(() => '')).toLowerCase();
-          const ariaLabel = ((await btn.getAttribute('aria-label')?.catch(() => '')) || '').toLowerCase();
-          if (text.includes('yes') || text.includes('open') || ariaLabel.includes('open workspace') || ariaLabel.includes('yes')) {
-            await btn.click();
-            clicked = true;
-            console.log(`[conversionYes] Clicked "${text || ariaLabel}" via raw selector`);
-            break;
-          }
-        }
-      } catch {
-        /* ignore */
-      }
-    }
+        assert.ok(activityIcons.length > 0, 'Logic Apps / Azure activity-bar item should be present');
 
-    // Strategy 4: JS click on notification action
-    if (!clicked) {
-      try {
-        clicked =
-          (await driver.executeScript<boolean>(`
-          var btns = document.querySelectorAll('.notification-toast .action-label, .notification-toast button, [role="dialog"] button');
-          for (var i = 0; i < btns.length; i++) {
-            var text = (btns[i].textContent || '').toLowerCase();
-            var aria = (btns[i].getAttribute('aria-label') || '').toLowerCase();
-            if (text.includes('yes') || text.includes('open') || aria.includes('open workspace')) {
-              btns[i].click();
-              return true;
+        // D3: no error notifications.
+        const notifications = await new Workbench().getNotifications().catch(() => []);
+        const errorFlags = await Promise.all(
+          notifications.map(async (n) => {
+            try {
+              return (await n.getType()) === NotificationType.Error;
+            } catch {
+              return false;
             }
-          }
-          return false;
-        `)) ?? false;
-        if (clicked) {
-          console.log('[conversionYes] Clicked via JS injection');
+          })
+        );
+        const errorCount = errorFlags.filter(Boolean).length;
+        assert.strictEqual(errorCount, 0, 'no error notifications should be present after conversion');
+      } catch (e) {
+        if (isSessionEnded(e)) {
+          // Session ended mid-UI-check — accept as the session-ended branch.
+          console.log('[conversionYes] Session ended during UI assertions — treating as reload');
+        } else {
+          throw e;
         }
+      }
+    } else {
+      console.log('[conversionYes] Session ended — skipping UI assertions (B1 path)');
+      // R9: capture diagnostic note for the session-ended path.
+      try {
+        fs.writeFileSync(
+          path.join(DIAGNOSTICS_DIR, 'session-ended.txt'),
+          `Selenium session ended at ${new Date().toISOString()} after pushing "${YES_BUTTON_LABEL}"\n`
+        );
       } catch {
         /* ignore */
       }
     }
 
-    await sleep(1000);
-    await captureScreenshot(driver, 'conversion-yes-after-click', EXPLICIT_SCREENSHOT_DIR);
-    assert.ok(clicked, '"Yes" / "Open Workspace" button should be clickable');
-
-    // After clicking Yes, VS Code may reload (killing the Selenium session).
-    // Wait briefly to see if we're still alive — if so, the click succeeded
-    // but the reload hasn't happened yet, which is fine.
-    await sleep(3000);
-    console.log('[conversionYes] PASSED — prompt appeared, accept button clicked');
+    console.log('[conversionYes] PASSED — prompt appeared, Yes clicked, post-conditions verified');
   });
 });


### PR DESCRIPTION
## Commit Type
- [x] test - Test-related changes

## Risk Level
- [x] Low - Minor changes, limited scope (test-only; product code untouched; `allowFailure: true` still gates Phase 4.8d)

## What & Why

Phase 4.8d (`workspaceConversionYes.test.ts`) has been an xvfb-flaky CI gate because the original test fought five overlapping race conditions:

1. It scanned for the prompt as a notification, but `convertToWorkspace.ts:119-121` creates it with `{ modal: true }`.
2. Two separate `new ModalDialog()` instantiations raced — the second went stale when the modal momentarily lost focus.
3. Hardcoded English button labels (`Yes` / `Open` / `Open Workspace` / `OK`) broke on localized CI runners.
4. No focus restore — xvfb does not auto-raise modal windows, so the underlying editor swallowed clicks aimed at the dialog.
5. A lingering quick-input from the prior phase ate the `File: Open Folder...` typing.

This PR applies the R1-R9 reliability fixes plus an A/B/C/D assertion package so the test fails loudly with diagnostic artifacts instead of silently passing by virtue of doing almost nothing.

**`allowFailure: true` is intentionally LEFT in place** at `run-e2e.js:932`, `:1890`, `:2067`. Removing it (R10) is the follow-up after 3 consecutive green CI runs prove the hardening works.

## Impact of Change

- **Users**: none — test-only change.
- **Developers**: new shared helpers `pushDialogButtonWithRetry`, `safeCancelAnyQuickInput`, `dumpDialogDiagnostics`, `isSessionEnded`, `focusModalPrimaryButton` available in `helpers.ts` for other modal-dialog conversion tests.
- **System**: `run-e2e.js` now exports `LANG=en_US.UTF-8`, `LC_ALL=en_US.UTF-8`, `VSCODE_NLS_CONFIG={"locale":"en-us"}` for the test subprocess to stabilize localized labels. No impact on shipped extension behavior.

### Reliability fixes (R1-R9)

- **R1** drop notification scanning — only ExTester `ModalDialog`
- **R2** single `ModalDialog` handle with stale-element retry (`pushDialogButtonWithRetry`)
- **R3** force-focus the modal primary button + `Tab+Enter` fallback (xvfb-robust default-button activation)
- **R4** locale lock via `LANG` / `LC_ALL` / `VSCODE_NLS_CONFIG` so `'Yes'` matches `DialogResponses.yes.title`
- **R5** `safeCancelAnyQuickInput(driver)` pre-flight cleanup before opening the folder
- **R6** `until.elementIsVisible` wait on the dialog button before clicking
- **R7** phase timeout 60s → 120s; modal prompt deadline 30s → 45s
- **R8** `dumpDialogDiagnostics` (title, URL, dialog count + text, notification count, active element) on click failure AND on prompt timeout
- **R9** milestone screenshots: test-start, prompt-found, focus-applied, post-click, session-ended marker

### Real assertions

- **A1-A7** pre-click FS invariants: `.code-workspace` exists & parses with `folders[]` resolving to `appDir`; `host.json`; `.vscode/launch.json` with a `logicapp`/`pwa-node`/`coreclr` configuration; `.vscode/tasks.json` with a `func: host start` task; `workflow.json`.
- **B1-B3** reload detection: window must (a) end the Selenium session (`invalid session id` / `chrome not reachable`), (b) flip the title to include `(Workspace)`, or (c) change URL. Any of those three is success.
- **C1-C3** post-reload FS reassertions: no `.vscode/extension-error.log`; `.code-workspace` mtime did not regress; A1-A7 still hold.
- **D1-D3** UI state (only when the session survives the click): no `.code-workspace` text editor open; Azure / Logic Apps activity-bar item present; zero error notifications.

Every Selenium call after `pushDialogButtonWithRetry` is wrapped against `isSessionEnded` so the expected B1 path (session ends because VS Code reloaded) is treated as success, not an error. UTF-8 BOM is stripped from `.code-workspace` reads on Windows.

`DialogResponses` is intentionally **not** imported: `@microsoft/vscode-azext-utils/out/src/DialogResponses.js` does `require('vscode')` at module load, and ExTester runs Mocha in a separate process where the `vscode` module is unavailable — so the import would crash the test at load time. We lock the locale instead (en-US matches `vscode.l10n.t('Yes')` → `'Yes'`).

## Test Plan

- [x] E2E tests updated (`apps/vs-code-designer/src/test/ui/workspaceConversionYes.test.ts`)
- [x] Tested in: local Biome (`biome check`) clean; local `tsup --config tsup.e2e.test.config.ts` succeeds; CI VS Code E2E shard `createplusconversion` will exercise Phase 4.8d on next push. ci-sentinel will iterate.
- Validation gate (R10): remove `allowFailure: true` after 3 consecutive green CI runs of Phase 4.8d. Not done in this PR.

## Contributors

- @lambrianmsft
- vscode-test-specialist + chief-engineer subagent workflow

## Screenshots/Videos

Milestone screenshots are captured to `$TEMP/test-resources/screenshots/wsConversionYes-explicit/` and diagnostics to `…/diagnostics/` on failure; CI artifacts will surface them.
