### PR TITLE
Verify extension bundle downloads end-to-end + surface progress to users

### DIFF
--- a/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/binaries.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import * as fs from 'fs';
 import axios from 'axios';
+import { EventEmitter } from 'events';
 import * as vscode from 'vscode';
 import {
   downloadAndExtractDependency,
+  downloadFileWithVerification,
+  DownloadIntegrityError,
   binariesExist,
   getLatestDotNetVersion,
   getLatestFunctionCoreToolsVersion,
@@ -47,36 +50,9 @@ describe('binaries', () => {
       context = {
         telemetry: {
           properties: {},
+          measurements: {},
         },
       } as IActionContext;
-    });
-
-    it('should download and extract dependency', async () => {
-      const downloadUrl = 'https://example.com/dependency.zip';
-      const targetFolder = 'targetFolder';
-      const dependencyName = 'dependency';
-      const folderName = 'folderName';
-      const dotNetVersion = '6.0';
-
-      const writer = {
-        on: vi.fn(),
-      } as any;
-
-      (axios.get as Mock).mockResolvedValue({
-        data: {
-          pipe: vi.fn().mockImplementation((writer) => {
-            writer.on('finish');
-          }),
-        },
-      });
-
-      (fs.createWriteStream as Mock).mockReturnValue(writer);
-
-      await downloadAndExtractDependency(context, downloadUrl, targetFolder, dependencyName, folderName, dotNetVersion);
-
-      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
-      expect(fs.chmodSync).toHaveBeenCalledWith(expect.any(String), 0o777);
-      expect(executeCommand).toHaveBeenCalledWith(ext.outputChannel, undefined, 'echo', `Downloading dependency from: ${downloadUrl}`);
     });
 
     it('should throw error when the compression file extension is not supported', async () => {
@@ -90,6 +66,123 @@ describe('binaries', () => {
         downloadAndExtractDependency(context, downloadUrl, targetFolder, dependencyName, folderName, dotNetVersion)
       ).rejects.toThrowError();
     });
+  });
+
+  describe('downloadFileWithVerification', () => {
+    let context: IActionContext;
+    const url = 'https://cdn.example.com/Microsoft.Azure.Functions.ExtensionBundle.Workflows.1.2.3_any-any.zip';
+    const destPath = '/tmp/dep.zip';
+    const dependencyName = 'TestDep';
+
+    beforeEach(() => {
+      context = {
+        telemetry: { properties: {}, measurements: {} },
+      } as IActionContext;
+      (fs.existsSync as Mock).mockReturnValue(false);
+    });
+
+    // Build a fake axios stream response. `chunks` are streamed in order;
+    // `headers` lets each test choose what the CDN reports.
+    function mockAxiosStream(chunks: string[], headers: Record<string, string>) {
+      const data = new EventEmitter() as EventEmitter & { pipe: (w: any) => any };
+      data.pipe = (writer: any) => {
+        // Schedule emission on the next microtask so test code can wire listeners.
+        setImmediate(() => {
+          for (const chunk of chunks) {
+            data.emit('data', Buffer.from(chunk));
+          }
+          writer.emit('finish');
+        });
+        return writer;
+      };
+      (axios.get as Mock).mockResolvedValueOnce({ headers, data });
+    }
+
+    function mockWriter() {
+      const writer = new EventEmitter() as EventEmitter & { write: Mock; end: Mock };
+      writer.write = vi.fn();
+      writer.end = vi.fn();
+      (fs.createWriteStream as Mock).mockReturnValueOnce(writer);
+      return writer;
+    }
+
+    it('verifies size and md5 from response headers on success', async () => {
+      mockWriter();
+      // MD5 of "hello world" in base64 = XrY7u+Ae7tCTyyK7j1rNww==
+      mockAxiosStream(['hello world'], {
+        'content-length': '11',
+        'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==',
+      });
+
+      const result = await downloadFileWithVerification(context, url, destPath, dependencyName);
+
+      expect(result.actualSize).toBe(11);
+      expect(result.expectedSize).toBe(11);
+      expect(result.expectedMd5).toBe('XrY7u+Ae7tCTyyK7j1rNww==');
+      expect(result.actualMd5).toBe('XrY7u+Ae7tCTyyK7j1rNww==');
+      expect(context.telemetry.properties[`${dependencyName}DownloadAttempts`]).toBe('1');
+      expect(context.telemetry.properties[`${dependencyName}Md5Match`]).toBe('true');
+    });
+
+    it('succeeds and reports skipped checks when headers are missing', async () => {
+      mockWriter();
+      mockAxiosStream(['abc'], {});
+
+      const result = await downloadFileWithVerification(context, url, destPath, dependencyName);
+
+      expect(result.expectedSize).toBeUndefined();
+      expect(result.expectedMd5).toBeUndefined();
+      expect(result.actualSize).toBe(3);
+      expect(context.telemetry.properties[`${dependencyName}Md5Match`]).toBe('skipped');
+      expect(context.telemetry.properties[`${dependencyName}ExpectedSize`]).toBe('unknown');
+    });
+
+    it('retries on size mismatch and ultimately fails with DownloadIntegrityError', async () => {
+      mockWriter();
+      mockAxiosStream(['short'], { 'content-length': '999', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+      mockWriter();
+      mockAxiosStream(['short'], { 'content-length': '999', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+      mockWriter();
+      mockAxiosStream(['short'], { 'content-length': '999', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+
+      await expect(downloadFileWithVerification(context, url, destPath, dependencyName, 3)).rejects.toBeInstanceOf(DownloadIntegrityError);
+      expect(axios.get).toHaveBeenCalledTimes(3);
+      expect(context.telemetry.properties[`${dependencyName}DownloadAttempts`]).toBe('3');
+    });
+
+    it('retries on md5 mismatch then succeeds on a later attempt', async () => {
+      // First attempt: corrupt body (md5 of 'corrupt' is not the expected one).
+      mockWriter();
+      mockAxiosStream(['corrupt'], { 'content-length': '11', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+      // Second attempt: matching body.
+      mockWriter();
+      mockAxiosStream(['hello world'], { 'content-length': '11', 'content-md5': 'XrY7u+Ae7tCTyyK7j1rNww==' });
+
+      const result = await downloadFileWithVerification(context, url, destPath, dependencyName, 3);
+
+      expect(result.actualSize).toBe(11);
+      expect(axios.get).toHaveBeenCalledTimes(2);
+      expect(context.telemetry.properties[`${dependencyName}DownloadAttempts`]).toBe('2');
+    }, 10000);
+
+    it('does not retry on 4xx HTTP errors', async () => {
+      const err = Object.assign(new Error('Not Found'), { response: { status: 404 } });
+      (axios.get as Mock).mockRejectedValueOnce(err);
+
+      await expect(downloadFileWithVerification(context, url, destPath, dependencyName, 3)).rejects.toBe(err);
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on 5xx HTTP errors', async () => {
+      const err5xx = Object.assign(new Error('Server Error'), { response: { status: 503 } });
+      (axios.get as Mock).mockRejectedValueOnce(err5xx);
+      mockWriter();
+      mockAxiosStream(['ok'], { 'content-length': '2' });
+
+      const result = await downloadFileWithVerification(context, url, destPath, dependencyName, 3);
+      expect(result.actualSize).toBe(2);
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    }, 10000);
   });
 
   describe('binariesExist', () => {

--- a/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
@@ -5,7 +5,7 @@ import {
   getLatestVersionRange,
   addDefaultBundle,
   downloadExtensionBundle,
-  resetCachedBundleVersion
+  resetCachedBundleVersion,
 } from '../bundleFeed';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fse from 'fs-extra';
@@ -27,6 +27,8 @@ vi.mock('fs-extra', async (importOriginal) => {
     pathExists: vi.fn(),
     readdirSync: vi.fn(),
     statSync: vi.fn(),
+    readFile: vi.fn(),
+    outputFile: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -93,6 +95,16 @@ vi.mock('../feed', () => ({
 // Mock binaries module
 vi.mock('../binaries', () => ({
   downloadAndExtractDependency: vi.fn(),
+}));
+
+// Mock integrity helpers (used by bundleFeed for HEAD-based hash verification)
+vi.mock('../integrity', () => ({
+  fetchExpectedMd5: vi.fn(),
+}));
+
+// Mock vsCodeConfig/settings — bundleFeed reads experimental settings from here.
+vi.mock('../vsCodeConfig/settings', () => ({
+  getGlobalSetting: vi.fn().mockReturnValue(undefined),
 }));
 
 // Mock localSettings
@@ -583,21 +595,52 @@ describe('downloadExtensionBundle', () => {
     },
   });
 
-  beforeEach(() => {
+  // Helper: configure fs-extra so that the bundle versions in `localVersions` exist on disk
+  // and the sidecar contents (if provided) round-trip when readBundleSidecar reads them.
+  const setupLocalDisk = (localVersions: string[], sidecarByVersion: Record<string, string> = {}) => {
+    mockedFse.readdirSync.mockReturnValue(localVersions as any);
+    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    mockedFse.pathExists.mockImplementation(((p: string) => {
+      // Default: bundle root and version folders exist; sidecar exists only when registered.
+      if (typeof p !== 'string') {
+        return Promise.resolve(true);
+      }
+      if (p.endsWith('.bundle-source-md5')) {
+        const matches = Object.keys(sidecarByVersion).some((v) => p.includes(v));
+        return Promise.resolve(matches);
+      }
+      return Promise.resolve(true);
+    }) as any);
+    mockedFse.readFile.mockImplementation(((p: string) => {
+      if (typeof p !== 'string') {
+        return Promise.resolve('' as any);
+      }
+      const match = Object.entries(sidecarByVersion).find(([v]) => p.includes(v));
+      return Promise.resolve((match?.[1] ?? '') as any);
+    }) as any);
+  };
+
+  beforeEach(async () => {
     vi.clearAllMocks();
     // Reset environment variables
     delete process.env.AzureFunctionsJobHost_extensionBundle_version;
     delete process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+    // Default: experimental settings disabled
+    const settingsModule = await import('../vsCodeConfig/settings');
+    vi.mocked(settingsModule.getGlobalSetting).mockReturnValue(undefined);
+    // Default: HEAD request returns nothing — keeps tests that don't care about sidecar simple.
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue(undefined);
+    // Reset fs-extra mocks
+    mockedFse.readFile.mockReset();
+    mockedFse.outputFile.mockResolvedValue(undefined as any);
   });
 
   it('should download newer version when feed has higher version than local', async () => {
     // Feed versions (simulating index.json format)
     const feedVersions = ['1.0.0', '1.1.0', '1.2.0', '1.3.0', '1.95.0'];
 
-    // Local version is 1.75.0
-    mockedFse.pathExists.mockResolvedValue(true as never);
-    mockedFse.readdirSync.mockReturnValue(['1.75.0'] as any);
-    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    setupLocalDisk(['1.75.0']);
 
     // Mock the feed to return the versions array
     mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
@@ -622,23 +665,80 @@ describe('downloadExtensionBundle', () => {
     );
   });
 
-  it('should not download when local version is higher than feed versions', async () => {
-    // Feed only has older versions
+  it('should not download when local version is higher than feed versions and the on-disk sidecar matches the published MD5', async () => {
     const feedVersions = ['1.0.0', '1.1.0', '1.2.0'];
-
-    // Local version is already 1.75.0
-    mockedFse.pathExists.mockResolvedValue(true as never);
-    mockedFse.readdirSync.mockReturnValue(['1.75.0'] as any);
-    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    // Local version is already 1.75.0 with a valid sidecar.
+    const matchingMd5 = 'matching-md5-base64';
+    setupLocalDisk(['1.75.0'], { '1.75.0': matchingMd5 });
 
     mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue(matchingMd5);
 
     const context = createMockContext();
     const result = await downloadExtensionBundle(context as any);
 
-    // Should not download
     expect(result).toBe(false);
     expect(context.telemetry.properties.didUpdateExtensionBundle).toBe('false');
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('passed');
+    expect(context.telemetry.properties.extensionBundleVersionSource).toBe('localLatest');
+    expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+  });
+
+  it('should re-download when local version equals feed but the sidecar is missing', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupLocalDisk(['1.95.0']); // no sidecar registered → readBundleSidecar returns undefined
+
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMissing');
+    expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('1.95.0'),
+      defaultExtensionBundlePathValue,
+      extensionBundleId,
+      '1.95.0'
+    );
+  });
+
+  it('should re-download when local version equals feed but the sidecar drifted from the published MD5', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupLocalDisk(['1.95.0'], { '1.95.0': 'old-md5' });
+
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('new-md5');
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMismatch');
+    expect(mockedDownloadAndExtract).toHaveBeenCalled();
+  });
+
+  it('should keep using local when the HEAD request fails', async () => {
+    const feedVersions = ['1.0.0', '1.95.0'];
+    setupLocalDisk(['1.95.0'], { '1.95.0': 'some-md5' });
+
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockRejectedValue(new Error('network down'));
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(false);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('headRequestFailed');
     expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
   });
 
@@ -646,9 +746,7 @@ describe('downloadExtensionBundle', () => {
     // Feed versions in random order
     const feedVersions = ['1.3.0', '1.95.0', '1.0.0', '1.50.0', '1.1.0'];
 
-    // No local versions
-    mockedFse.pathExists.mockResolvedValue(true as never);
-    mockedFse.readdirSync.mockReturnValue([] as any);
+    setupLocalDisk([]);
 
     mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
     mockedDownloadAndExtract.mockResolvedValue(undefined);
@@ -671,10 +769,7 @@ describe('downloadExtensionBundle', () => {
     // Feed has 1.95.0
     const feedVersions = ['1.0.0', '1.95.0'];
 
-    // Multiple local versions, highest is 1.75.0
-    mockedFse.pathExists.mockResolvedValue(true as never);
-    mockedFse.readdirSync.mockReturnValue(['1.50.0', '1.75.0', '1.60.0'] as any);
-    mockedFse.statSync.mockReturnValue({ isDirectory: () => true } as any);
+    setupLocalDisk(['1.50.0', '1.75.0', '1.60.0']);
 
     mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
     mockedDownloadAndExtract.mockResolvedValue(undefined);
@@ -691,5 +786,199 @@ describe('downloadExtensionBundle', () => {
       extensionBundleId,
       '1.95.0'
     );
+  });
+
+  describe('experimental extension bundle', () => {
+    const setExperimentalSettings = async (values: { useExperimental?: boolean; sourceUri?: string; pinnedVersion?: string } = {}) => {
+      const settingsModule = await import('../vsCodeConfig/settings');
+      vi.mocked(settingsModule.getGlobalSetting).mockImplementation((key: string) => {
+        if (key === 'useExperimentalExtensionBundle') {
+          return values.useExperimental as any;
+        }
+        if (key === 'experimentalExtensionBundleSourceUri') {
+          return (values.sourceUri ?? '') as any;
+        }
+        if (key === 'experimentalExtensionBundleVersion') {
+          return (values.pinnedVersion ?? '') as any;
+        }
+        return undefined;
+      });
+    };
+
+    it('uses the pinned local version and never calls the public feed', async () => {
+      await setExperimentalSettings({ useExperimental: true, pinnedVersion: '1.21.0' });
+      setupLocalDisk(['1.21.0']);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(false);
+      expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+      expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalLocalPin');
+    });
+
+    it('downloads the pinned version from the experimental URI when missing on disk', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        pinnedVersion: '1.21.0-preview',
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk(['1.20.0']); // pin not on disk
+      mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+      expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('https://private-cdn.example.com/public'),
+        defaultExtensionBundlePathValue,
+        extensionBundleId,
+        '1.21.0-preview'
+      );
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalFirstDownload');
+    });
+
+    it('falls back to latest local version when pin is set but missing and source URI is empty', async () => {
+      await setExperimentalSettings({ useExperimental: true, pinnedVersion: '1.21.0', sourceUri: '' });
+      setupLocalDisk(['1.20.0']); // pin not on disk
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(false);
+      expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+      expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalLocalLatest');
+    });
+
+    it('uses latest local without consulting the public feed when no pin is set', async () => {
+      await setExperimentalSettings({ useExperimental: true });
+      setupLocalDisk(['1.50.0', '1.75.0']);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(false);
+      expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+      expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalLocalLatest');
+    });
+
+    it('cold-starts from the experimental URI when nothing is on disk', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk([]);
+      mockedGetJsonFeed.mockResolvedValue(['1.10.0', '1.21.0-preview'] as any);
+      mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      // Should fetch the experimental index, not the public one.
+      const calledWith = (mockedGetJsonFeed.mock.calls[0]?.[1] as string) ?? '';
+      expect(calledWith).toContain('https://private-cdn.example.com/public');
+      expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('https://private-cdn.example.com/public'),
+        defaultExtensionBundlePathValue,
+        extensionBundleId,
+        '1.21.0-preview'
+      );
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalFirstDownload');
+    });
+
+    it('falls through to the public feed when toggle is on but no pin / no local / no source URI', async () => {
+      await setExperimentalSettings({ useExperimental: true });
+      setupLocalDisk([]);
+      mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      expect(context.telemetry.properties.experimentalFellThroughToPublic).toBe('true');
+      expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('1.95.0'),
+        defaultExtensionBundlePathValue,
+        extensionBundleId,
+        '1.95.0'
+      );
+    });
+  });
+});
+
+describe('getExtensionBundleBaseUrl', () => {
+  let getExtensionBundleBaseUrl: typeof import('../bundleFeed').getExtensionBundleBaseUrl;
+  let settingsModule: typeof import('../vsCodeConfig/settings');
+  let localSettingsMod: typeof import('../appSettings/localSettings');
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    delete process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+    ({ getExtensionBundleBaseUrl } = await import('../bundleFeed'));
+    settingsModule = await import('../vsCodeConfig/settings');
+    localSettingsMod = await import('../appSettings/localSettings');
+    vi.mocked(settingsModule.getGlobalSetting).mockReturnValue(undefined);
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({} as any);
+  });
+
+  const ctx = () => ({
+    telemetry: { properties: {} as Record<string, string>, measurements: {} as Record<string, number> },
+  });
+
+  it('uses local.settings.json over everything else', async () => {
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({
+      Values: { FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI: 'https://from-local-settings' },
+    } as any);
+    process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI = 'https://from-env';
+    vi.mocked(settingsModule.getGlobalSetting).mockImplementation((key: string) =>
+      key === 'useExperimentalExtensionBundle'
+        ? (true as any)
+        : key === 'experimentalExtensionBundleSourceUri'
+          ? ('https://from-vscode' as any)
+          : undefined
+    );
+
+    const c = ctx();
+    const result = await getExtensionBundleBaseUrl(c as any);
+    expect(result.baseUrl).toBe('https://from-local-settings');
+    expect(result.source).toBe('localSettings');
+    expect(c.telemetry.properties.extensionBundleBaseUrlSource).toBe('localSettings');
+  });
+
+  it('uses process.env when local.settings.json is empty', async () => {
+    process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI = 'https://from-env';
+    const result = await getExtensionBundleBaseUrl(ctx() as any);
+    expect(result.baseUrl).toBe('https://from-env');
+    expect(result.source).toBe('envVar');
+  });
+
+  it('uses experimental setting when toggle is on and the higher-precedence sources are empty', async () => {
+    vi.mocked(settingsModule.getGlobalSetting).mockImplementation((key: string) =>
+      key === 'useExperimentalExtensionBundle'
+        ? (true as any)
+        : key === 'experimentalExtensionBundleSourceUri'
+          ? ('https://from-vscode' as any)
+          : undefined
+    );
+    const result = await getExtensionBundleBaseUrl(ctx() as any);
+    expect(result.baseUrl).toBe('https://from-vscode');
+    expect(result.source).toBe('experimentalSetting');
+    expect(result.isExperimental).toBe(true);
+  });
+
+  it('falls back to the public CDN when nothing is configured', async () => {
+    const result = await getExtensionBundleBaseUrl(ctx() as any);
+    expect(result.baseUrl).toBe('https://cdn.functions.azure.com/public');
+    expect(result.source).toBe('default');
   });
 });

--- a/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
@@ -85,6 +85,15 @@ vi.mock('vscode', () => ({
       },
     ],
   },
+  window: {
+    // Invoke the task immediately so the wrapped download still runs and
+    // produces its side effects (mockedDownloadAndExtract calls, etc.).
+    withProgress: vi.fn(async (_opts: unknown, task: (...args: unknown[]) => Promise<unknown>) => task()),
+    showInformationMessage: vi.fn(),
+    showWarningMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+  },
+  ProgressLocation: { Notification: 15, SourceControl: 1, Window: 10 },
 }));
 
 // Mock feed module
@@ -751,6 +760,45 @@ describe('downloadExtensionBundle', () => {
     expect(result).toBe(false);
     expect(context.telemetry.properties.localBundleHashCheck).toBe('headRequestFailed');
     expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+  });
+
+  it('shows a warning toast + progress notification when a corrupt local bundle is re-downloaded', async () => {
+    const vscode = await import('vscode');
+    const feedVersions = ['1.0.0', '1.95.0'];
+    // Local 1.95.0 with a sidecar that mismatches the CDN's published MD5.
+    setupLocalDisk(['1.95.0'], { '1.95.0': 'stale-on-disk-md5' });
+    mockedGetJsonFeed.mockResolvedValue(feedVersions as any);
+    const integrityModule = await import('../integrity');
+    vi.mocked(integrityModule.fetchExpectedMd5).mockResolvedValue('fresh-cdn-md5');
+    mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(context.telemetry.properties.localBundleHashCheck).toBe('sidecarMismatch');
+    expect(vi.mocked(vscode.window.showWarningMessage)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(vscode.window.showWarningMessage).mock.calls[0]?.[0]).toMatch(/incomplete|checksum/i);
+    expect(vi.mocked(vscode.window.withProgress)).toHaveBeenCalled();
+    const progressTitle = (vi.mocked(vscode.window.withProgress).mock.calls[0]?.[0] as any)?.title ?? '';
+    expect(progressTitle).toMatch(/Re-downloading.*1\.95\.0/);
+    expect(vi.mocked(vscode.window.showInformationMessage)).toHaveBeenCalledWith(expect.stringMatching(/1\.95\.0.*ready/i));
+  });
+
+  it('shows a progress notification when a newer feed version is downloaded (no corruption warning)', async () => {
+    const vscode = await import('vscode');
+    setupLocalDisk(['1.75.0']);
+    mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+    mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(vi.mocked(vscode.window.showWarningMessage)).not.toHaveBeenCalled();
+    const progressTitle = (vi.mocked(vscode.window.withProgress).mock.calls[0]?.[0] as any)?.title ?? '';
+    expect(progressTitle).toMatch(/Downloading newer.*1\.95\.0/);
+    expect(vi.mocked(vscode.window.showInformationMessage)).toHaveBeenCalledWith(expect.stringMatching(/1\.95\.0.*ready/i));
   });
 
   it('should correctly identify the latest version from an unordered feed list', async () => {

--- a/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
+++ b/apps/vs-code-designer/src/app/utils/__test__/bundleFeed.test.ts
@@ -100,6 +100,17 @@ vi.mock('../binaries', () => ({
 // Mock integrity helpers (used by bundleFeed for HEAD-based hash verification)
 vi.mock('../integrity', () => ({
   fetchExpectedMd5: vi.fn(),
+  isMissingPackageError: (error: unknown) => {
+    const status = (error as { response?: { status?: number } })?.response?.status;
+    if (typeof status === 'number') {
+      return status >= 400 && status < 500;
+    }
+    const code = (error as { code?: string })?.code;
+    if (typeof code === 'string') {
+      return code === 'ENOTFOUND' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'EAI_AGAIN' || code === 'ECONNRESET';
+    }
+    return false;
+  },
 }));
 
 // Mock vsCodeConfig/settings — bundleFeed reads experimental settings from here.
@@ -788,6 +799,47 @@ describe('downloadExtensionBundle', () => {
     );
   });
 
+  it('does not re-download when the env-var-pinned version is one of several local versions', async () => {
+    // Phase 5 bug fix: previously this used `semver.eq(envVarVer, latestLocalBundleVersion)`,
+    // which returned false when the pin was not the *highest* local version, causing a
+    // pointless redownload. Membership in localVersions is the right check.
+    const localSettingsMod = await import('../appSettings/localSettings');
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({
+      Values: { AzureFunctionsJobHost_extensionBundle_version: '1.50.0' },
+    } as any);
+    setupLocalDisk(['1.50.0', '1.60.0']);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(false);
+    expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
+    expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+    expect(context.telemetry.properties.extensionBundleVersionSource).toBe('envVar');
+    expect(context.telemetry.properties.didUpdateExtensionBundle).toBe('false');
+  });
+
+  it('downloads exactly the env-var-pinned version when not on disk', async () => {
+    const localSettingsMod = await import('../appSettings/localSettings');
+    vi.mocked(localSettingsMod.getLocalSettingsJson).mockResolvedValue({
+      Values: { AzureFunctionsJobHost_extensionBundle_version: '1.50.0' },
+    } as any);
+    setupLocalDisk(['1.60.0']);
+    mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+    const context = createMockContext();
+    const result = await downloadExtensionBundle(context as any);
+
+    expect(result).toBe(true);
+    expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('1.50.0'),
+      defaultExtensionBundlePathValue,
+      extensionBundleId,
+      '1.50.0'
+    );
+  });
+
   describe('experimental extension bundle', () => {
     const setExperimentalSettings = async (values: { useExperimental?: boolean; sourceUri?: string; pinnedVersion?: string } = {}) => {
       const settingsModule = await import('../vsCodeConfig/settings');
@@ -825,13 +877,18 @@ describe('downloadExtensionBundle', () => {
         sourceUri: 'https://private-cdn.example.com/public',
       });
       setupLocalDisk(['1.20.0']); // pin not on disk
+      // Source URI's index lists the pin.
+      mockedGetJsonFeed.mockResolvedValue(['1.10.0', '1.21.0-preview'] as any);
       mockedDownloadAndExtract.mockResolvedValue(undefined);
 
       const context = createMockContext();
       const result = await downloadExtensionBundle(context as any);
 
       expect(result).toBe(true);
-      expect(mockedGetJsonFeed).not.toHaveBeenCalled();
+      // Index is probed against the experimental URI only — never the public CDN.
+      const indexCall = (mockedGetJsonFeed.mock.calls[0]?.[1] as string) ?? '';
+      expect(indexCall).toContain('https://private-cdn.example.com/public');
+      expect(mockedDownloadAndExtract).toHaveBeenCalledTimes(1);
       expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
         expect.anything(),
         expect.stringContaining('https://private-cdn.example.com/public'),
@@ -840,19 +897,29 @@ describe('downloadExtensionBundle', () => {
         '1.21.0-preview'
       );
       expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalFirstDownload');
+      expect(context.telemetry.properties.experimentalSourceFallback).toBeUndefined();
     });
 
-    it('falls back to latest local version when pin is set but missing and source URI is empty', async () => {
+    it('falls back to the public CDN for the pin when source URI is empty and pin is not on disk', async () => {
+      // I3 in the plan: pin set, not on disk, no sourceUri → download `pin` from public CDN.
       await setExperimentalSettings({ useExperimental: true, pinnedVersion: '1.21.0', sourceUri: '' });
       setupLocalDisk(['1.20.0']); // pin not on disk
+      mockedDownloadAndExtract.mockResolvedValue(undefined);
 
       const context = createMockContext();
       const result = await downloadExtensionBundle(context as any);
 
-      expect(result).toBe(false);
+      expect(result).toBe(true);
+      // No index probe (no sourceUri to probe).
       expect(mockedGetJsonFeed).not.toHaveBeenCalled();
-      expect(mockedDownloadAndExtract).not.toHaveBeenCalled();
-      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalLocalLatest');
+      expect(mockedDownloadAndExtract).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('cdn.functions.azure.com/public'),
+        defaultExtensionBundlePathValue,
+        extensionBundleId,
+        '1.21.0'
+      );
+      expect(context.telemetry.properties.extensionBundleVersionSource).toBe('experimentalFirstDownload');
     });
 
     it('uses latest local without consulting the public feed when no pin is set', async () => {
@@ -912,6 +979,148 @@ describe('downloadExtensionBundle', () => {
         extensionBundleId,
         '1.95.0'
       );
+    });
+
+    // ----- Phase 5 fallback tests -----
+
+    const make404 = () => {
+      const err: any = new Error('Request failed with status code 404');
+      err.response = { status: 404, headers: {}, data: '' };
+      err.isAxiosError = true;
+      return err;
+    };
+    const makeNetworkError = () => {
+      const err: any = new Error('getaddrinfo ENOTFOUND private-cdn.example.com');
+      err.code = 'ENOTFOUND';
+      err.isAxiosError = true;
+      return err;
+    };
+
+    it('falls back to the public CDN when the experimental URI returns 404 for the pinned zip', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        pinnedVersion: '1.21.0-preview',
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk(['1.20.0']);
+      // Index probe lists the pin so we proceed to download from the source.
+      mockedGetJsonFeed.mockResolvedValue(['1.21.0-preview'] as any);
+      // Source download 404s, public download succeeds.
+      mockedDownloadAndExtract.mockRejectedValueOnce(make404()).mockResolvedValueOnce(undefined as any);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      expect(mockedDownloadAndExtract).toHaveBeenCalledTimes(2);
+      const firstUrl = mockedDownloadAndExtract.mock.calls[0]?.[1] as string;
+      const secondUrl = mockedDownloadAndExtract.mock.calls[1]?.[1] as string;
+      expect(firstUrl).toContain('private-cdn.example.com');
+      expect(secondUrl).toContain('cdn.functions.azure.com/public');
+      expect(secondUrl).toContain('1.21.0-preview');
+      expect(context.telemetry.properties.experimentalSourceFallback).toBe('zip404');
+      expect(context.telemetry.properties.experimentalSourceFallbackTarget).toBe('public');
+    });
+
+    it('falls back to the public CDN when the experimental index does not list the pin', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        pinnedVersion: '1.21.0-preview',
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk(['1.20.0']);
+      // Index probe succeeds but pin is missing.
+      mockedGetJsonFeed.mockResolvedValue(['1.10.0', '1.20.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      // Only one download — straight to public, no source-zip attempt.
+      expect(mockedDownloadAndExtract).toHaveBeenCalledTimes(1);
+      const url = mockedDownloadAndExtract.mock.calls[0]?.[1] as string;
+      expect(url).toContain('cdn.functions.azure.com/public');
+      expect(url).toContain('1.21.0-preview');
+      expect(context.telemetry.properties.experimentalSourceFallback).toBe('pinNotInIndex');
+    });
+
+    it('falls back to the public feed when the experimental index returns 404 (cold start, no pin)', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk([]);
+      // First getJsonFeed call (experimental index) 404s, second call (public feed) succeeds.
+      mockedGetJsonFeed.mockRejectedValueOnce(make404()).mockResolvedValueOnce(['1.0.0', '1.95.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      expect(context.telemetry.properties.experimentalSourceFallback).toBe('index404');
+      expect(context.telemetry.properties.experimentalFellThroughToPublic).toBe('true');
+      const url = mockedDownloadAndExtract.mock.calls.at(-1)?.[1] as string;
+      expect(url).toContain('cdn.functions.azure.com/public');
+      expect(url).toContain('1.95.0');
+    });
+
+    it('falls back to the public feed on a network error to the experimental URI (cold start, no pin)', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk([]);
+      mockedGetJsonFeed.mockRejectedValueOnce(makeNetworkError()).mockResolvedValueOnce(['1.0.0', '1.95.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      expect(context.telemetry.properties.experimentalSourceFallback).toBe('networkError');
+      expect(context.telemetry.properties.experimentalFellThroughToPublic).toBe('true');
+    });
+
+    it('throws when both the experimental URI and the public CDN 404 for the pinned version', async () => {
+      await setExperimentalSettings({
+        useExperimental: true,
+        pinnedVersion: '9.9.9-bogus',
+        sourceUri: 'https://private-cdn.example.com/public',
+      });
+      setupLocalDisk(['1.20.0']);
+      mockedGetJsonFeed.mockResolvedValue(['9.9.9-bogus'] as any);
+      mockedDownloadAndExtract.mockRejectedValueOnce(make404()).mockRejectedValueOnce(make404());
+
+      const context = createMockContext();
+      // The outer try/catch in downloadExtensionBundle swallows + records the
+      // error; result is `false` and telemetry preserves the failure reason.
+      const result = await downloadExtensionBundle(context as any);
+      expect(result).toBe(false);
+      expect(mockedDownloadAndExtract).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not honor the source URI when the master toggle is off', async () => {
+      await setExperimentalSettings({
+        useExperimental: false,
+        sourceUri: 'https://private-cdn.example.com/public',
+        pinnedVersion: '1.21.0-preview',
+      });
+      setupLocalDisk(['1.20.0']);
+      mockedGetJsonFeed.mockResolvedValue(['1.0.0', '1.95.0'] as any);
+      mockedDownloadAndExtract.mockResolvedValue(undefined);
+
+      const context = createMockContext();
+      const result = await downloadExtensionBundle(context as any);
+
+      expect(result).toBe(true);
+      // Public CDN, public latest — toggle off means experimental settings are ignored.
+      const url = mockedDownloadAndExtract.mock.calls[0]?.[1] as string;
+      expect(url).toContain('cdn.functions.azure.com/public');
+      expect(url).toContain('1.95.0');
+      expect(url).not.toContain('private-cdn.example.com');
+      expect(url).not.toContain('1.21.0-preview');
     });
   });
 });

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -26,6 +26,7 @@ import { onboardBinaries, useBinariesDependencies } from './runtimeDependencies'
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { Platform, type IGitHubReleaseInfo } from '@microsoft/vscode-extension-logic-apps';
 import axios from 'axios';
+import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -68,71 +69,236 @@ export async function downloadAndExtractDependency(
   const dependencyFilePath = path.join(tempFolderPath, `${dependencyName}${dependencyFileExtension}`);
 
   executeCommand(ext.outputChannel, undefined, 'echo', `Downloading dependency from: ${downloadUrl}`);
+  fs.mkdirSync(tempFolderPath, { recursive: true });
+  fs.chmodSync(tempFolderPath, 0o777);
 
-  axios.get(downloadUrl, { responseType: 'stream' }).then((response) => {
-    executeCommand(ext.outputChannel, undefined, 'echo', `Creating temporary folder... ${tempFolderPath}`);
-    fs.mkdirSync(tempFolderPath, { recursive: true });
-    fs.chmodSync(tempFolderPath, 0o777);
-
-    const writer = fs.createWriteStream(dependencyFilePath);
-    response.data.pipe(writer);
-
-    writer.on('finish', async () => {
-      executeCommand(ext.outputChannel, undefined, 'echo', `Successfully downloaded ${dependencyName} dependency.`);
-      fs.chmodSync(dependencyFilePath, 0o777);
-
-      // Extract to targetFolder
-      if (dependencyName === dotnetDependencyName) {
-        const version = dotNetVersion ?? semver.major(DependencyVersion.dotnet8);
-        if (process.platform === Platform.windows) {
-          await executeCommand(
-            ext.outputChannel,
-            undefined,
-            'powershell -ExecutionPolicy Bypass -File',
-            dependencyFilePath,
-            '-InstallDir',
-            targetFolder,
-            '-Channel',
-            `${version}.0`
-          );
-        } else {
-          await executeCommand(ext.outputChannel, undefined, dependencyFilePath, '-InstallDir', targetFolder, '-Channel', `${version}.0`);
-        }
-      } else {
-        if (dependencyName === funcDependencyName || dependencyName === extensionBundleId) {
-          stopAllDesignTimeApis();
-        }
-        await extractDependency(dependencyFilePath, targetFolder, dependencyName);
-        vscode.window.showInformationMessage(localize('successInstall', `Successfully installed ${dependencyName}`));
-        if (dependencyName === funcDependencyName) {
-          // Add execute permissions for func and gozip binaries
-          if (process.platform !== Platform.windows) {
-            fs.chmodSync(`${targetFolder}/func`, 0o755);
-            fs.chmodSync(`${targetFolder}/gozip`, 0o755);
-            fs.chmodSync(`${targetFolder}/in-proc8/func`, 0o755);
-            fs.chmodSync(`${targetFolder}/in-proc6/func`, 0o755);
-          }
-          await setFunctionsCommand();
-          await startAllDesignTimeApis();
-        } else if (dependencyName === extensionBundleId) {
-          await startAllDesignTimeApis();
-        }
+  try {
+    await downloadFileWithVerification(context, downloadUrl, dependencyFilePath, dependencyName);
+  } catch (error) {
+    const errorMessage = `Error downloading the ${dependencyName} file: ${error instanceof Error ? error.message : String(error)}`;
+    vscode.window.showErrorMessage(errorMessage);
+    context.telemetry.properties.error = errorMessage;
+    // Clean up partials before bailing.
+    try {
+      if (fs.existsSync(tempFolderPath)) {
+        fs.rmSync(tempFolderPath, { recursive: true, force: true });
       }
-      // remove the temp folder.
-      fs.rmSync(tempFolderPath, { recursive: true });
-      executeCommand(ext.outputChannel, undefined, 'echo', `Removed ${tempFolderPath}`);
-    });
-    writer.on('error', async (error) => {
-      // log the error message the VSCode window and to telemetry.
-      const errorMessage = `Error downloading and extracting the ${dependencyName} zip file: ${error.message}`;
-      vscode.window.showErrorMessage(errorMessage);
-      context.telemetry.properties.error = errorMessage;
+      if (fs.existsSync(targetFolder)) {
+        fs.rmSync(targetFolder, { recursive: true, force: true });
+      }
+    } catch {
+      // Best-effort cleanup; ignore secondary errors.
+    }
+    throw error;
+  }
 
-      // remove the target folder.
-      fs.rmSync(targetFolder, { recursive: true });
-      await executeCommand(ext.outputChannel, undefined, 'echo', `[ExtractError]: Removed ${targetFolder}`);
-    });
+  executeCommand(ext.outputChannel, undefined, 'echo', `Successfully downloaded ${dependencyName} dependency.`);
+  fs.chmodSync(dependencyFilePath, 0o777);
+
+  try {
+    // Extract to targetFolder
+    if (dependencyName === dotnetDependencyName) {
+      const version = dotNetVersion ?? semver.major(DependencyVersion.dotnet8);
+      if (process.platform === Platform.windows) {
+        await executeCommand(
+          ext.outputChannel,
+          undefined,
+          'powershell -ExecutionPolicy Bypass -File',
+          dependencyFilePath,
+          '-InstallDir',
+          targetFolder,
+          '-Channel',
+          `${version}.0`
+        );
+      } else {
+        await executeCommand(ext.outputChannel, undefined, dependencyFilePath, '-InstallDir', targetFolder, '-Channel', `${version}.0`);
+      }
+    } else {
+      if (dependencyName === funcDependencyName || dependencyName === extensionBundleId) {
+        stopAllDesignTimeApis();
+      }
+      await extractDependency(dependencyFilePath, targetFolder, dependencyName);
+      vscode.window.showInformationMessage(localize('successInstall', `Successfully installed ${dependencyName}`));
+      if (dependencyName === funcDependencyName) {
+        // Add execute permissions for func and gozip binaries
+        if (process.platform !== Platform.windows) {
+          fs.chmodSync(`${targetFolder}/func`, 0o755);
+          fs.chmodSync(`${targetFolder}/gozip`, 0o755);
+          fs.chmodSync(`${targetFolder}/in-proc8/func`, 0o755);
+          fs.chmodSync(`${targetFolder}/in-proc6/func`, 0o755);
+        }
+        await setFunctionsCommand();
+        await startAllDesignTimeApis();
+      } else if (dependencyName === extensionBundleId) {
+        await startAllDesignTimeApis();
+      }
+    }
+  } finally {
+    // remove the temp folder.
+    if (fs.existsSync(tempFolderPath)) {
+      fs.rmSync(tempFolderPath, { recursive: true, force: true });
+      executeCommand(ext.outputChannel, undefined, 'echo', `Removed ${tempFolderPath}`);
+    }
+  }
+}
+
+/**
+ * Error thrown when a downloaded file fails integrity verification
+ * (size or MD5 mismatch against the response headers).
+ */
+export class DownloadIntegrityError extends Error {
+  constructor(
+    public readonly url: string,
+    public readonly reason: 'size' | 'md5',
+    public readonly expected: string,
+    public readonly actual: string
+  ) {
+    super(`Download integrity check failed for ${url}: ${reason} mismatch (expected ${expected}, got ${actual}).`);
+    this.name = 'DownloadIntegrityError';
+  }
+}
+
+interface DownloadAttemptResult {
+  expectedSize?: number;
+  actualSize: number;
+  expectedMd5?: string;
+  actualMd5: string;
+}
+
+const DEFAULT_DOWNLOAD_MAX_ATTEMPTS = 3;
+
+/**
+ * Streams a file from `url` to `destPath`, verifying integrity against
+ * `Content-Length` and `Content-MD5` response headers when present.
+ *
+ * Azure Blob Storage (which backs cdn.functions.azure.com) sets both headers
+ * on upload, so this catches CDN-edge truncation/corruption end-to-end without
+ * any publishing-pipeline changes.
+ *
+ * Retries on network errors and integrity failures with exponential backoff.
+ */
+export async function downloadFileWithVerification(
+  context: IActionContext,
+  url: string,
+  destPath: string,
+  dependencyName: string,
+  maxAttempts: number = DEFAULT_DOWNLOAD_MAX_ATTEMPTS
+): Promise<DownloadAttemptResult> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const attemptStart = Date.now();
+    try {
+      const result = await downloadFileAttempt(url, destPath);
+
+      context.telemetry.properties[`${dependencyName}DownloadAttempts`] = String(attempt);
+      context.telemetry.properties[`${dependencyName}ExpectedSize`] =
+        result.expectedSize === undefined ? 'unknown' : String(result.expectedSize);
+      context.telemetry.properties[`${dependencyName}ActualSize`] = String(result.actualSize);
+      context.telemetry.properties[`${dependencyName}Md5Match`] = result.expectedMd5 ? 'true' : 'skipped';
+      context.telemetry.measurements ??= {};
+      context.telemetry.measurements[`${dependencyName}DownloadDurationMs`] = Date.now() - attemptStart;
+
+      return result;
+    } catch (error) {
+      lastError = error;
+      // Clean up the partial file before retrying.
+      try {
+        if (fs.existsSync(destPath)) {
+          fs.rmSync(destPath, { force: true });
+        }
+      } catch {
+        // ignore cleanup failures
+      }
+
+      const isRetryable = isRetryableDownloadError(error);
+      const willRetry = isRetryable && attempt < maxAttempts;
+      executeCommand(
+        ext.outputChannel,
+        undefined,
+        'echo',
+        `Download attempt ${attempt}/${maxAttempts} for ${dependencyName} failed: ${
+          error instanceof Error ? error.message : String(error)
+        }${willRetry ? ' — retrying.' : ''}`
+      );
+
+      if (!willRetry) {
+        context.telemetry.properties[`${dependencyName}DownloadAttempts`] = String(attempt);
+        throw error;
+      }
+      // Exponential backoff: 1s, 2s, 4s, ...
+      await delay(1000 * 2 ** (attempt - 1));
+    }
+  }
+  // Unreachable — the loop either returns or throws — but TypeScript needs this.
+  throw lastError;
+}
+
+function downloadFileAttempt(url: string, destPath: string): Promise<DownloadAttemptResult> {
+  return new Promise<DownloadAttemptResult>((resolve, reject) => {
+    axios
+      .get(url, { responseType: 'stream' })
+      .then((response) => {
+        const headers = response.headers ?? {};
+        const contentLengthRaw = headers['content-length'] ?? headers['Content-Length'];
+        const expectedSize = contentLengthRaw === undefined ? undefined : Number.parseInt(String(contentLengthRaw), 10);
+        const expectedMd5Raw = headers['content-md5'] ?? headers['Content-MD5'];
+        const expectedMd5 = typeof expectedMd5Raw === 'string' && expectedMd5Raw.length > 0 ? expectedMd5Raw : undefined;
+
+        const writer = fs.createWriteStream(destPath);
+        const hash = createHash('md5');
+        let actualSize = 0;
+        let settled = false;
+
+        const settle = (fn: () => void) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          fn();
+        };
+
+        response.data.on('data', (chunk: Buffer) => {
+          actualSize += chunk.length;
+          hash.update(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+        });
+        response.data.on('error', (err: Error) => settle(() => reject(err)));
+        writer.on('error', (err: Error) => settle(() => reject(err)));
+        writer.on('finish', () =>
+          settle(() => {
+            if (expectedSize !== undefined && Number.isFinite(expectedSize) && actualSize !== expectedSize) {
+              reject(new DownloadIntegrityError(url, 'size', String(expectedSize), String(actualSize)));
+              return;
+            }
+            const actualMd5 = hash.digest('base64');
+            if (expectedMd5 && actualMd5 !== expectedMd5) {
+              reject(new DownloadIntegrityError(url, 'md5', expectedMd5, actualMd5));
+              return;
+            }
+            resolve({ expectedSize, actualSize, expectedMd5, actualMd5 });
+          })
+        );
+
+        response.data.pipe(writer);
+      })
+      .catch((err) => reject(err));
   });
+}
+
+function isRetryableDownloadError(error: unknown): boolean {
+  if (error instanceof DownloadIntegrityError) {
+    return true;
+  }
+  // Axios errors carry a `response` only for HTTP responses; treat 5xx/network as retryable, 4xx as fatal.
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  if (typeof status === 'number') {
+    return status >= 500 && status < 600;
+  }
+  // No HTTP response at all — likely a network/socket error worth retrying.
+  return true;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const getFunctionCoreToolVersionFromGithub = async (context: IActionContext, majorVersion: string): Promise<string> => {

--- a/apps/vs-code-designer/src/app/utils/binaries.ts
+++ b/apps/vs-code-designer/src/app/utils/binaries.ts
@@ -23,10 +23,10 @@ import { executeCommand } from './funcCoreTools/cpUtils';
 import { getNpmCommand } from './nodeJs/nodeJsVersion';
 import { getGlobalSetting, getWorkspaceSetting, updateGlobalSetting } from './vsCodeConfig/settings';
 import { onboardBinaries, useBinariesDependencies } from './runtimeDependencies';
+import { type DownloadAttemptResult, downloadFileWithVerification as downloadFileWithVerificationCore } from './integrity';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import { Platform, type IGitHubReleaseInfo } from '@microsoft/vscode-extension-logic-apps';
 import axios from 'axios';
-import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -39,6 +39,8 @@ import { setFunctionsCommand } from './funcCoreTools/funcVersion';
 import { startAllDesignTimeApis, stopAllDesignTimeApis } from './codeless/startDesignTimeApi';
 
 export { useBinariesDependencies } from './runtimeDependencies';
+export { DownloadIntegrityError } from './integrity';
+export type { DownloadAttemptResult } from './integrity';
 
 /**
  * Download and Extracts dependency zip.
@@ -56,7 +58,7 @@ export async function downloadAndExtractDependency(
   dependencyName: string,
   folderName?: string,
   dotNetVersion?: string
-): Promise<void> {
+): Promise<DownloadAttemptResult | undefined> {
   folderName = folderName || dependencyName;
   const tempFolderPath = path.join(os.tmpdir(), defaultLogicAppsFolder, folderName);
   targetFolder = path.join(targetFolder, folderName);
@@ -72,8 +74,9 @@ export async function downloadAndExtractDependency(
   fs.mkdirSync(tempFolderPath, { recursive: true });
   fs.chmodSync(tempFolderPath, 0o777);
 
+  let integrityResult: DownloadAttemptResult | undefined;
   try {
-    await downloadFileWithVerification(context, downloadUrl, dependencyFilePath, dependencyName);
+    integrityResult = await downloadFileWithVerification(context, downloadUrl, dependencyFilePath, dependencyName);
   } catch (error) {
     const errorMessage = `Error downloading the ${dependencyName} file: ${error instanceof Error ? error.message : String(error)}`;
     vscode.window.showErrorMessage(errorMessage);
@@ -140,165 +143,59 @@ export async function downloadAndExtractDependency(
       executeCommand(ext.outputChannel, undefined, 'echo', `Removed ${tempFolderPath}`);
     }
   }
-}
 
-/**
- * Error thrown when a downloaded file fails integrity verification
- * (size or MD5 mismatch against the response headers).
- */
-export class DownloadIntegrityError extends Error {
-  constructor(
-    public readonly url: string,
-    public readonly reason: 'size' | 'md5',
-    public readonly expected: string,
-    public readonly actual: string
-  ) {
-    super(`Download integrity check failed for ${url}: ${reason} mismatch (expected ${expected}, got ${actual}).`);
-    this.name = 'DownloadIntegrityError';
-  }
+  return integrityResult;
 }
-
-interface DownloadAttemptResult {
-  expectedSize?: number;
-  actualSize: number;
-  expectedMd5?: string;
-  actualMd5: string;
-}
-
-const DEFAULT_DOWNLOAD_MAX_ATTEMPTS = 3;
 
 /**
  * Streams a file from `url` to `destPath`, verifying integrity against
  * `Content-Length` and `Content-MD5` response headers when present.
  *
- * Azure Blob Storage (which backs cdn.functions.azure.com) sets both headers
- * on upload, so this catches CDN-edge truncation/corruption end-to-end without
- * any publishing-pipeline changes.
- *
- * Retries on network errors and integrity failures with exponential backoff.
+ * Thin wrapper that adds extension-host telemetry + log lines on top of the
+ * vscode-free implementation in `./integrity`.
  */
 export async function downloadFileWithVerification(
   context: IActionContext,
   url: string,
   destPath: string,
   dependencyName: string,
-  maxAttempts: number = DEFAULT_DOWNLOAD_MAX_ATTEMPTS
+  maxAttempts?: number
 ): Promise<DownloadAttemptResult> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const attemptStart = Date.now();
-    try {
-      const result = await downloadFileAttempt(url, destPath);
-
-      context.telemetry.properties[`${dependencyName}DownloadAttempts`] = String(attempt);
-      context.telemetry.properties[`${dependencyName}ExpectedSize`] =
-        result.expectedSize === undefined ? 'unknown' : String(result.expectedSize);
-      context.telemetry.properties[`${dependencyName}ActualSize`] = String(result.actualSize);
-      context.telemetry.properties[`${dependencyName}Md5Match`] = result.expectedMd5 ? 'true' : 'skipped';
-      context.telemetry.measurements ??= {};
-      context.telemetry.measurements[`${dependencyName}DownloadDurationMs`] = Date.now() - attemptStart;
-
-      return result;
-    } catch (error) {
-      lastError = error;
-      // Clean up the partial file before retrying.
-      try {
-        if (fs.existsSync(destPath)) {
-          fs.rmSync(destPath, { force: true });
-        }
-      } catch {
-        // ignore cleanup failures
-      }
-
-      const isRetryable = isRetryableDownloadError(error);
-      const willRetry = isRetryable && attempt < maxAttempts;
-      executeCommand(
-        ext.outputChannel,
-        undefined,
-        'echo',
-        `Download attempt ${attempt}/${maxAttempts} for ${dependencyName} failed: ${
-          error instanceof Error ? error.message : String(error)
-        }${willRetry ? ' — retrying.' : ''}`
-      );
-
-      if (!willRetry) {
-        context.telemetry.properties[`${dependencyName}DownloadAttempts`] = String(attempt);
-        throw error;
-      }
-      // Exponential backoff: 1s, 2s, 4s, ...
-      await delay(1000 * 2 ** (attempt - 1));
+  let attemptsUsed = 0;
+  try {
+    const result = await downloadFileWithVerificationCore(url, destPath, {
+      maxAttempts,
+      hooks: {
+        onSuccess: (attempt, attemptResult, durationMs) => {
+          attemptsUsed = attempt;
+          context.telemetry.properties[`${dependencyName}DownloadAttempts`] = String(attempt);
+          context.telemetry.properties[`${dependencyName}ExpectedSize`] =
+            attemptResult.expectedSize === undefined ? 'unknown' : String(attemptResult.expectedSize);
+          context.telemetry.properties[`${dependencyName}ActualSize`] = String(attemptResult.actualSize);
+          context.telemetry.properties[`${dependencyName}Md5Match`] = attemptResult.expectedMd5 ? 'true' : 'skipped';
+          context.telemetry.measurements ??= {};
+          context.telemetry.measurements[`${dependencyName}DownloadDurationMs`] = durationMs;
+        },
+        onAttempt: (attempt, error, willRetry) => {
+          attemptsUsed = attempt;
+          executeCommand(
+            ext.outputChannel,
+            undefined,
+            'echo',
+            `Download attempt ${attempt} for ${dependencyName} failed: ${
+              error instanceof Error ? error.message : String(error)
+            }${willRetry ? ' — retrying.' : ''}`
+          );
+        },
+      },
+    });
+    return result;
+  } catch (error) {
+    if (attemptsUsed > 0) {
+      context.telemetry.properties[`${dependencyName}DownloadAttempts`] = String(attemptsUsed);
     }
+    throw error;
   }
-  // Unreachable — the loop either returns or throws — but TypeScript needs this.
-  throw lastError;
-}
-
-function downloadFileAttempt(url: string, destPath: string): Promise<DownloadAttemptResult> {
-  return new Promise<DownloadAttemptResult>((resolve, reject) => {
-    axios
-      .get(url, { responseType: 'stream' })
-      .then((response) => {
-        const headers = response.headers ?? {};
-        const contentLengthRaw = headers['content-length'] ?? headers['Content-Length'];
-        const expectedSize = contentLengthRaw === undefined ? undefined : Number.parseInt(String(contentLengthRaw), 10);
-        const expectedMd5Raw = headers['content-md5'] ?? headers['Content-MD5'];
-        const expectedMd5 = typeof expectedMd5Raw === 'string' && expectedMd5Raw.length > 0 ? expectedMd5Raw : undefined;
-
-        const writer = fs.createWriteStream(destPath);
-        const hash = createHash('md5');
-        let actualSize = 0;
-        let settled = false;
-
-        const settle = (fn: () => void) => {
-          if (settled) {
-            return;
-          }
-          settled = true;
-          fn();
-        };
-
-        response.data.on('data', (chunk: Buffer) => {
-          actualSize += chunk.length;
-          hash.update(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
-        });
-        response.data.on('error', (err: Error) => settle(() => reject(err)));
-        writer.on('error', (err: Error) => settle(() => reject(err)));
-        writer.on('finish', () =>
-          settle(() => {
-            if (expectedSize !== undefined && Number.isFinite(expectedSize) && actualSize !== expectedSize) {
-              reject(new DownloadIntegrityError(url, 'size', String(expectedSize), String(actualSize)));
-              return;
-            }
-            const actualMd5 = hash.digest('base64');
-            if (expectedMd5 && actualMd5 !== expectedMd5) {
-              reject(new DownloadIntegrityError(url, 'md5', expectedMd5, actualMd5));
-              return;
-            }
-            resolve({ expectedSize, actualSize, expectedMd5, actualMd5 });
-          })
-        );
-
-        response.data.pipe(writer);
-      })
-      .catch((err) => reject(err));
-  });
-}
-
-function isRetryableDownloadError(error: unknown): boolean {
-  if (error instanceof DownloadIntegrityError) {
-    return true;
-  }
-  // Axios errors carry a `response` only for HTTP responses; treat 5xx/network as retryable, 4xx as fatal.
-  const status = (error as { response?: { status?: number } })?.response?.status;
-  if (typeof status === 'number') {
-    return status >= 500 && status < 600;
-  }
-  // No HTTP response at all — likely a network/socket error worth retrying.
-  return true;
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const getFunctionCoreToolVersionFromGithub = async (context: IActionContext, majorVersion: string): Promise<string> => {

--- a/apps/vs-code-designer/src/app/utils/bundleFeed.ts
+++ b/apps/vs-code-designer/src/app/utils/bundleFeed.ts
@@ -2,10 +2,21 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { defaultVersionRange, extensionBundleId, localSettingsFileName, defaultExtensionBundlePathValue } from '../../constants';
+import {
+  defaultVersionRange,
+  extensionBundleId,
+  localSettingsFileName,
+  defaultExtensionBundlePathValue,
+  bundleSourceMd5SidecarFile,
+  useExperimentalExtensionBundleSettingKey,
+  experimentalExtensionBundleSourceUriSettingKey,
+  experimentalExtensionBundleVersionSettingKey,
+} from '../../constants';
 import { getLocalSettingsJson } from './appSettings/localSettings';
 import { downloadAndExtractDependency } from './binaries';
+import { fetchExpectedMd5 } from './integrity';
 import { getJsonFeed } from './feed';
+import { getGlobalSetting } from './vsCodeConfig/settings';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
 import type { IBundleDependencyFeed, IBundleMetadata, IHostJsonV2 } from '@microsoft/vscode-extension-logic-apps';
 import * as path from 'path';
@@ -17,16 +28,83 @@ import { getFunctionsCommand } from './funcCoreTools/funcVersion';
 import * as fse from 'fs-extra';
 import { executeCommand } from './funcCoreTools/cpUtils';
 
+const PUBLIC_BUNDLE_BASE_URL = 'https://cdn.functions.azure.com/public';
+
+export type BundleBaseUrlSource = 'localSettings' | 'envVar' | 'experimentalSetting' | 'default';
+export type BundleVersionSource =
+  | 'envVar'
+  | 'experimentalLocalPin'
+  | 'experimentalFirstDownload'
+  | 'experimentalLocalLatest'
+  | 'publicFeedLatest'
+  | 'localLatest';
+
+interface ExtensionBundleBaseUrlResult {
+  baseUrl: string;
+  source: BundleBaseUrlSource;
+  isExperimental: boolean;
+  experimentalSourceUri: string;
+  experimentalPinnedVersion: string;
+}
+
+/**
+ * Resolves the base URL used for fetching the extension bundle index, dependency feed,
+ * and zip — plus the experimental settings that may alter version-selection behavior.
+ *
+ * Precedence (highest → lowest):
+ *   1. Workspace `local.settings.json` value `FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI`.
+ *   2. `process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI`.
+ *   3. VS Code experimental setting `experimentalExtensionBundleSourceUri` (only when
+ *      `useExperimentalExtensionBundle` is `true` and the URI is non-empty).
+ *   4. Default public CDN.
+ */
+export async function getExtensionBundleBaseUrl(context: IActionContext): Promise<ExtensionBundleBaseUrlResult> {
+  const projectPath: string | undefined = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
+  let localSettingsUri: string | undefined;
+  if (projectPath) {
+    try {
+      localSettingsUri = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
+        ?.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+    } catch {
+      // Missing/invalid local.settings.json is fine; fall through to other sources.
+    }
+  }
+
+  const envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+  const isExperimental = getGlobalSetting<boolean>(useExperimentalExtensionBundleSettingKey) === true;
+  const experimentalSourceUri = (getGlobalSetting<string>(experimentalExtensionBundleSourceUriSettingKey) ?? '').trim();
+  const experimentalPinnedVersion = (getGlobalSetting<string>(experimentalExtensionBundleVersionSettingKey) ?? '').trim();
+
+  let baseUrl: string;
+  let source: BundleBaseUrlSource;
+  if (localSettingsUri && localSettingsUri.length > 0) {
+    baseUrl = localSettingsUri;
+    source = 'localSettings';
+  } else if (envVarUri && envVarUri.length > 0) {
+    baseUrl = envVarUri;
+    source = 'envVar';
+  } else if (isExperimental && experimentalSourceUri.length > 0) {
+    baseUrl = experimentalSourceUri;
+    source = 'experimentalSetting';
+  } else {
+    baseUrl = PUBLIC_BUNDLE_BASE_URL;
+    source = 'default';
+  }
+
+  context.telemetry.properties.extensionBundleBaseUrlSource = source;
+  context.telemetry.properties.useExperimentalExtensionBundle = String(isExperimental);
+
+  return { baseUrl, source, isExperimental, experimentalSourceUri, experimentalPinnedVersion };
+}
+
 /**
  * Gets Workflow bundle extension feed.
  * @param {IActionContext} context - Command context.
  * @returns {Promise<string[]>} Returns array of available bundle versions.
  */
 async function getWorkflowBundleFeed(context: IActionContext): Promise<string[]> {
-  const envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  const baseUrl: string = envVarUri || 'https://cdn.functions.azure.com/public';
+  const { baseUrl } = await getExtensionBundleBaseUrl(context);
   const url = `${baseUrl}/ExtensionBundles/${extensionBundleId}/index.json`;
-
   return getJsonFeed(context, url);
 }
 
@@ -41,14 +119,7 @@ async function getBundleDependencyFeed(
   bundleMetadata: IBundleMetadata | undefined
 ): Promise<IBundleDependencyFeed> {
   const bundleId: string = (bundleMetadata && bundleMetadata?.id) || extensionBundleId;
-  const projectPath: string | undefined = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
-  let envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  if (projectPath) {
-    envVarUri = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
-      ?.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  }
-
-  const baseUrl: string = envVarUri || 'https://cdn.functions.azure.com/public';
+  const { baseUrl } = await getExtensionBundleBaseUrl(context);
   const url = `${baseUrl}/ExtensionBundles/${bundleId}/dependency.json`;
   return getJsonFeed(context, url);
 }
@@ -83,22 +154,46 @@ export function addDefaultBundle(hostJson: IHostJsonV2): void {
 }
 
 /**
- * Gets bundle extension zip. Microsoft.Azure.Functions.ExtensionBundle.Workflows.<version>.
- * @param {IActionContext} context - Command context.
- * @param {string} extensionVersion - Bundle Extension Version.
- * @returns {string} Returns bundle extension zip url.
+ * Builds the URL to the bundle's zip on the configured base URL.
  */
-async function getExtensionBundleZip(context: IActionContext, extensionVersion: string): Promise<string> {
-  let envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  const projectPath: string | undefined = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
-  if (projectPath) {
-    envVarUri = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
-      ?.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
-  }
-  const baseUrl: string = envVarUri || 'https://cdn.functions.azure.com/public';
-  const url = `${baseUrl}/ExtensionBundles/${extensionBundleId}/${extensionVersion}/${extensionBundleId}.${extensionVersion}_any-any.zip`;
+function buildExtensionBundleZipUrl(baseUrl: string, extensionVersion: string): string {
+  return `${baseUrl}/ExtensionBundles/${extensionBundleId}/${extensionVersion}/${extensionBundleId}.${extensionVersion}_any-any.zip`;
+}
 
-  return url;
+/**
+ * Returns the absolute path of the on-disk MD5 sidecar for a given bundle version.
+ * The sidecar is written by `downloadExtensionBundle` after a successful download
+ * so subsequent startups can confirm the bundle still matches the publisher's
+ * `Content-MD5` header without re-downloading.
+ */
+function getBundleSidecarPath(version: string): string {
+  return path.join(defaultExtensionBundlePathValue, version, bundleSourceMd5SidecarFile);
+}
+
+async function readBundleSidecar(version: string): Promise<string | undefined> {
+  const sidecarPath = getBundleSidecarPath(version);
+  try {
+    if (!(await fse.pathExists(sidecarPath))) {
+      return undefined;
+    }
+    const value = (await fse.readFile(sidecarPath, 'utf8')).trim();
+    return value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function writeBundleSidecar(version: string, md5: string): Promise<void> {
+  const sidecarPath = getBundleSidecarPath(version);
+  try {
+    await fse.outputFile(sidecarPath, md5, 'utf8');
+  } catch (writeError) {
+    if (ext.outputChannel) {
+      ext.outputChannel.appendLog(
+        localize('bundleSidecarWriteFailed', 'Failed to write extension-bundle MD5 sidecar at "{0}": {1}', sidecarPath, String(writeError))
+      );
+    }
+  }
 }
 
 /**
@@ -121,6 +216,69 @@ async function getExtensionBundleVersionFolders(directoryPath: string): Promise<
   return folders;
 }
 
+function pickLatestVersion(versions: string[]): string {
+  let latest = '0.0.0';
+  for (const v of versions) {
+    if (semver.valid(v) && semver.gt(v, latest)) {
+      latest = v;
+    }
+  }
+  return latest;
+}
+
+/**
+ * Downloads the bundle zip from the resolved base URL and writes the sidecar.
+ * Used both for the standard "feed wins" path and for the experimental cold-start path.
+ */
+async function downloadBundleAndWriteSidecar(context: IActionContext, baseUrl: string, version: string): Promise<void> {
+  const zipUrl = buildExtensionBundleZipUrl(baseUrl, version);
+  const result = await downloadAndExtractDependency(context, zipUrl, defaultExtensionBundlePathValue, extensionBundleId, version);
+  if (result?.actualMd5) {
+    await writeBundleSidecar(version, result.actualMd5);
+  }
+}
+
+/**
+ * Verifies the on-disk bundle's source MD5 against what the public CDN currently
+ * reports via HEAD. Used only when the experimental toggle is OFF.
+ */
+async function verifyLocalBundleHash(
+  context: IActionContext,
+  publicBaseUrl: string,
+  localVersion: string
+): Promise<'passed' | 'sidecarMissing' | 'sidecarMismatch' | 'headRequestFailed'> {
+  const sidecarValue = await readBundleSidecar(localVersion);
+  if (!sidecarValue) {
+    return 'sidecarMissing';
+  }
+
+  const headUrl = buildExtensionBundleZipUrl(publicBaseUrl, localVersion);
+  let publishedMd5: string | undefined;
+  try {
+    publishedMd5 = await fetchExpectedMd5(headUrl);
+  } catch (error) {
+    if (ext.outputChannel) {
+      ext.outputChannel.appendLog(
+        localize(
+          'bundleHashHeadFailed',
+          'Failed to verify extension-bundle MD5 against {0}: {1}',
+          headUrl,
+          error instanceof Error ? error.message : String(error)
+        )
+      );
+    }
+    context.telemetry.properties.bundleHashHeadError = error instanceof Error ? error.message : String(error);
+    return 'headRequestFailed';
+  }
+
+  if (!publishedMd5) {
+    // Server didn't return a Content-MD5 — can't verify either way; treat as passed
+    // so we don't pointlessly re-download just because the CDN dropped the header.
+    return 'passed';
+  }
+  return publishedMd5 === sidecarValue ? 'passed' : 'sidecarMismatch';
+}
+
 /**
  * Download Microsoft.Azure.Functions.ExtensionBundle.Workflows.<version>
  * Destination: C:\Users\<USERHOME>\.azure-functions-core-tools\Functions\ExtensionBundles\<version>
@@ -128,41 +286,102 @@ async function getExtensionBundleVersionFolders(directoryPath: string): Promise<
  * @returns {Promise<bool>} A boolean indicating whether the bundle was updated.
  */
 export async function downloadExtensionBundle(context: IActionContext): Promise<boolean> {
+  const downloadExtensionBundleStartTime = Date.now();
   try {
-    const downloadExtensionBundleStartTime = Date.now();
     let envVarVer: string | undefined = process.env.AzureFunctionsJobHost_extensionBundle_version;
     const projectPath: string | undefined = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : null;
     if (projectPath) {
-      envVarVer = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
-        ?.AzureFunctionsJobHost_extensionBundle_version;
+      try {
+        envVarVer = (await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName)))?.Values
+          ?.AzureFunctionsJobHost_extensionBundle_version;
+      } catch {
+        // ignore
+      }
     }
 
-    // Check for latest version at directory.
-    let latestLocalBundleVersion = '1.0.0';
     const localVersions = await getExtensionBundleVersionFolders(defaultExtensionBundlePathValue);
-    for (const localVersion of localVersions) {
-      latestLocalBundleVersion = semver.gt(latestLocalBundleVersion, localVersion) ? latestLocalBundleVersion : localVersion;
-    }
+    const latestLocalBundleVersion = pickLatestVersion(localVersions);
+    const baseUrlInfo = await getExtensionBundleBaseUrl(context);
 
     context.telemetry.properties.envVariableExtensionBundleVersion = envVarVer;
+
+    // 1. Pinned via env / local.settings.json — existing behavior.
     if (envVarVer) {
-      if (semver.eq(envVarVer, latestLocalBundleVersion)) {
+      context.telemetry.properties.extensionBundleVersionSource = 'envVar';
+      if (latestLocalBundleVersion !== '0.0.0' && semver.valid(envVarVer) && semver.eq(envVarVer, latestLocalBundleVersion)) {
         return false;
       }
-
-      const extensionBundleUrl = await getExtensionBundleZip(context, envVarVer);
-      await downloadAndExtractDependency(context, extensionBundleUrl, defaultExtensionBundlePathValue, extensionBundleId, envVarVer);
+      await downloadBundleAndWriteSidecar(context, baseUrlInfo.baseUrl, envVarVer);
       context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
       context.telemetry.properties.didUpdateExtensionBundle = 'true';
       return true;
     }
 
-    // Check the latest from feed.
-    let latestFeedBundleVersion = '1.0.0';
-    const feedVersions: string[] = await getWorkflowBundleFeed(context);
-    for (const bundleVersion of feedVersions) {
-      latestFeedBundleVersion = semver.gt(latestFeedBundleVersion, bundleVersion) ? latestFeedBundleVersion : bundleVersion;
+    // 2. Experimental toggle on — never call the public feed.
+    if (baseUrlInfo.isExperimental) {
+      const pin = baseUrlInfo.experimentalPinnedVersion;
+
+      if (pin && pin.length > 0) {
+        const pinIsLocal = localVersions.some((v) => v === pin);
+        if (pinIsLocal) {
+          ext.defaultBundleVersion = pin;
+          ext.latestBundleVersion = pin;
+          context.telemetry.properties.extensionBundleVersionSource = 'experimentalLocalPin';
+          context.telemetry.properties.didUpdateExtensionBundle = 'false';
+          return false;
+        }
+        if (baseUrlInfo.experimentalSourceUri.length > 0) {
+          await downloadBundleAndWriteSidecar(context, baseUrlInfo.experimentalSourceUri, pin);
+          ext.defaultBundleVersion = pin;
+          ext.latestBundleVersion = pin;
+          context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
+          context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+          context.telemetry.properties.didUpdateExtensionBundle = 'true';
+          return true;
+        }
+        // Pin set, not on disk, no source URI — fall through to "no pin" path below.
+      }
+
+      if (latestLocalBundleVersion !== '0.0.0') {
+        ext.defaultBundleVersion = latestLocalBundleVersion;
+        ext.latestBundleVersion = latestLocalBundleVersion;
+        context.telemetry.properties.extensionBundleVersionSource = 'experimentalLocalLatest';
+        context.telemetry.properties.didUpdateExtensionBundle = 'false';
+        return false;
+      }
+
+      if (baseUrlInfo.experimentalSourceUri.length > 0) {
+        // Cold start with no pin: ask the experimental source for its index and grab its latest.
+        const experimentalIndexUrl = `${baseUrlInfo.experimentalSourceUri}/ExtensionBundles/${extensionBundleId}/index.json`;
+        const experimentalFeed: string[] = await getJsonFeed(context, experimentalIndexUrl);
+        const experimentalLatest = pickLatestVersion(experimentalFeed);
+        if (experimentalLatest === '0.0.0') {
+          throw new Error(
+            localize(
+              'experimentalBundleEmpty',
+              'Experimental extension-bundle source "{0}" returned no versions.',
+              baseUrlInfo.experimentalSourceUri
+            )
+          );
+        }
+        await downloadBundleAndWriteSidecar(context, baseUrlInfo.experimentalSourceUri, experimentalLatest);
+        ext.defaultBundleVersion = experimentalLatest;
+        ext.latestBundleVersion = experimentalLatest;
+        context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
+        context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+        context.telemetry.properties.didUpdateExtensionBundle = 'true';
+        return true;
+      }
+      // Toggle is on but no pin, no local, no experimental URI — fall through to public-feed flow
+      // so the dev isn't dead-in-the-water just because they enabled the toggle without configuring
+      // anything else.
+      context.telemetry.properties.experimentalFellThroughToPublic = 'true';
     }
+
+    // 3. Default flow: use latest local if intact; otherwise re-download from CDN.
+    let latestFeedBundleVersion = '0.0.0';
+    const feedVersions: string[] = await getWorkflowBundleFeed(context);
+    latestFeedBundleVersion = pickLatestVersion(feedVersions);
 
     context.telemetry.properties.latestBundleVersion = semver.gt(latestFeedBundleVersion, latestLocalBundleVersion)
       ? latestFeedBundleVersion
@@ -172,25 +391,36 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
     ext.latestBundleVersion = context.telemetry.properties.latestBundleVersion;
 
     if (semver.gt(latestFeedBundleVersion, latestLocalBundleVersion)) {
-      const extensionBundleUrl = await getExtensionBundleZip(context, latestFeedBundleVersion);
-      await downloadAndExtractDependency(
-        context,
-        extensionBundleUrl,
-        defaultExtensionBundlePathValue,
-        extensionBundleId,
-        latestFeedBundleVersion
-      );
-
+      await downloadBundleAndWriteSidecar(context, baseUrlInfo.baseUrl, latestFeedBundleVersion);
+      context.telemetry.properties.extensionBundleVersionSource = 'publicFeedLatest';
+      context.telemetry.properties.localBundleHashCheck = 'skipped';
       context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
       context.telemetry.properties.didUpdateExtensionBundle = 'true';
       return true;
     }
 
+    // Local is at least as new as the feed — verify the on-disk bundle's source MD5
+    // and re-download if it's missing or has drifted (e.g. CDN republished the same version).
+    if (latestLocalBundleVersion !== '0.0.0') {
+      const hashCheck = await verifyLocalBundleHash(context, baseUrlInfo.baseUrl, latestLocalBundleVersion);
+      context.telemetry.properties.localBundleHashCheck = hashCheck;
+      if (hashCheck === 'sidecarMissing' || hashCheck === 'sidecarMismatch') {
+        await downloadBundleAndWriteSidecar(context, baseUrlInfo.baseUrl, latestLocalBundleVersion);
+        context.telemetry.properties.extensionBundleVersionSource = 'publicFeedLatest';
+        context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+        context.telemetry.properties.didUpdateExtensionBundle = 'true';
+        return true;
+      }
+    } else {
+      context.telemetry.properties.localBundleHashCheck = 'skipped';
+    }
+
+    context.telemetry.properties.extensionBundleVersionSource = 'localLatest';
     context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
     context.telemetry.properties.didUpdateExtensionBundle = 'false';
     return false;
   } catch (error) {
-    const errorMessage = `Error downloading and extracting the Logic Apps Standard extension bundle: ${error.message}`;
+    const errorMessage = `Error downloading and extracting the Logic Apps Standard extension bundle: ${error instanceof Error ? error.message : String(error)}`;
     context.telemetry.properties.errorMessage = errorMessage;
     return false;
   }

--- a/apps/vs-code-designer/src/app/utils/bundleFeed.ts
+++ b/apps/vs-code-designer/src/app/utils/bundleFeed.ts
@@ -309,6 +309,133 @@ function logExperimentalFallback(context: IActionContext, reason: ExperimentalSo
 }
 
 /**
+ * Why we're about to (re)download a bundle — drives the user-facing
+ * notification copy so the user understands *why* something is being
+ * downloaded, not just *that* it is.
+ */
+type DownloadReason =
+  | 'newerVersion'
+  | 'sidecarMissing'
+  | 'sidecarMismatch'
+  | 'experimentalPin'
+  | 'experimentalLatest'
+  | 'envVarPin'
+  | 'fallbackPublic';
+
+function describeSource(baseUrl: string): string {
+  if (baseUrl.startsWith(PUBLIC_BUNDLE_BASE_URL)) {
+    return localize('bundleSourcePublic', 'public Azure CDN');
+  }
+  return baseUrl;
+}
+
+function buildProgressTitle(version: string, reason: DownloadReason, baseUrl: string): string {
+  const source = describeSource(baseUrl);
+  switch (reason) {
+    case 'sidecarMissing':
+    case 'sidecarMismatch':
+      return localize(
+        'bundleProgressRedownload',
+        'Re-downloading Logic Apps extension bundle {0} from {1} (local copy was incomplete)…',
+        version,
+        source
+      );
+    case 'newerVersion':
+      return localize('bundleProgressNewer', 'Downloading newer Logic Apps extension bundle {0} from {1}…', version, source);
+    case 'experimentalPin':
+      return localize('bundleProgressPin', 'Downloading pinned Logic Apps extension bundle {0} from {1}…', version, source);
+    case 'experimentalLatest':
+      return localize(
+        'bundleProgressExperimental',
+        'Downloading Logic Apps extension bundle {0} from experimental source {1}…',
+        version,
+        source
+      );
+    case 'envVarPin':
+      return localize(
+        'bundleProgressEnvVar',
+        'Downloading Logic Apps extension bundle {0} pinned by host.json/env from {1}…',
+        version,
+        source
+      );
+    case 'fallbackPublic':
+      return localize(
+        'bundleProgressFallback',
+        'Experimental source could not deliver Logic Apps extension bundle {0}; downloading from public Azure CDN…',
+        version
+      );
+    default:
+      return localize('bundleProgressGeneric', 'Downloading Logic Apps extension bundle {0}…', version);
+  }
+}
+
+/**
+ * Surfaces a one-time warning toast when we detect that the local copy of
+ * the bundle is corrupt / incomplete. We always follow it with the actual
+ * download (which the user also sees via the progress notification), so
+ * the warning is informational only — no buttons.
+ */
+function notifyCorruptionDetected(version: string, source: string): void {
+  vscode.window.showWarningMessage(
+    localize(
+      'bundleCorruptionDetected',
+      'Logic Apps extension bundle {0} on disk is incomplete or its checksum no longer matches {1}. Re-downloading.',
+      version,
+      source
+    )
+  );
+}
+
+/**
+ * Wraps `downloadBundleAndWriteSidecar` in a `withProgress` notification and
+ * shows a success toast so the user can see what's happening rather than
+ * silently waiting on activation.
+ *
+ * Tests stub `vscode.window.withProgress` to immediately invoke its task, so
+ * this stays unit-testable.
+ */
+async function downloadBundleWithProgress(
+  context: IActionContext,
+  baseUrl: string,
+  version: string,
+  reason: DownloadReason
+): Promise<void> {
+  const title = buildProgressTitle(version, reason, baseUrl);
+  if (ext.outputChannel) {
+    ext.outputChannel.appendLog(title);
+  }
+  await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title, cancellable: false }, async () => {
+    await downloadBundleAndWriteSidecar(context, baseUrl, version);
+  });
+  vscode.window.showInformationMessage(localize('bundleDownloadReady', 'Logic Apps extension bundle {0} is ready.', version));
+}
+
+/**
+ * Progress-wrapped variant of `tryDownloadBundleAndWriteSidecar` for the
+ * experimental → public fallback chain. Behaves identically to the bare
+ * helper but surfaces a progress notification during the attempt.
+ */
+async function tryDownloadBundleWithProgress(
+  context: IActionContext,
+  baseUrl: string,
+  version: string,
+  reason: DownloadReason
+): Promise<{ ok: true } | { ok: false; reason: ExperimentalSourceFallbackReason; error: unknown }> {
+  const title = buildProgressTitle(version, reason, baseUrl);
+  if (ext.outputChannel) {
+    ext.outputChannel.appendLog(title);
+  }
+  let outcome: { ok: true } | { ok: false; reason: ExperimentalSourceFallbackReason; error: unknown } = { ok: true };
+  await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title, cancellable: false }, async () => {
+    outcome = await tryDownloadBundleAndWriteSidecar(context, baseUrl, version);
+  });
+  if (outcome.ok) {
+    vscode.window.showInformationMessage(localize('bundleDownloadReady', 'Logic Apps extension bundle {0} is ready.', version));
+  }
+  return outcome;
+}
+
+/**
  * Verifies the on-disk bundle's source MD5 against what the public CDN currently
  * reports via HEAD. Used only when the experimental toggle is OFF.
  */
@@ -389,7 +516,7 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
         context.telemetry.properties.didUpdateExtensionBundle = 'false';
         return false;
       }
-      await downloadBundleAndWriteSidecar(context, baseUrlInfo.baseUrl, envVarVer);
+      await downloadBundleWithProgress(context, baseUrlInfo.baseUrl, envVarVer, 'envVarPin');
       context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
       context.telemetry.properties.didUpdateExtensionBundle = 'true';
       return true;
@@ -422,7 +549,7 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
           // telemetry reason is accurate.
           const indexProbe = await tryFetchSourceIndex(context, baseUrlInfo.experimentalSourceUri);
           if (indexProbe.ok && indexProbe.versions.includes(pin)) {
-            const result = await tryDownloadBundleAndWriteSidecar(context, baseUrlInfo.experimentalSourceUri, pin);
+            const result = await tryDownloadBundleWithProgress(context, baseUrlInfo.experimentalSourceUri, pin, 'experimentalPin');
             if (result.ok) {
               ext.defaultBundleVersion = pin;
               ext.latestBundleVersion = pin;
@@ -445,7 +572,7 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
         }
 
         // Fallback: download the pin from the public CDN.
-        await downloadBundleAndWriteSidecar(context, PUBLIC_BUNDLE_BASE_URL, pin);
+        await downloadBundleWithProgress(context, PUBLIC_BUNDLE_BASE_URL, pin, 'fallbackPublic');
         ext.defaultBundleVersion = pin;
         ext.latestBundleVersion = pin;
         context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
@@ -470,7 +597,12 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
         if (indexProbe.ok) {
           const experimentalLatest = pickLatestVersion(indexProbe.versions);
           if (experimentalLatest !== '0.0.0') {
-            const result = await tryDownloadBundleAndWriteSidecar(context, baseUrlInfo.experimentalSourceUri, experimentalLatest);
+            const result = await tryDownloadBundleWithProgress(
+              context,
+              baseUrlInfo.experimentalSourceUri,
+              experimentalLatest,
+              'experimentalLatest'
+            );
             if (result.ok) {
               ext.defaultBundleVersion = experimentalLatest;
               ext.latestBundleVersion = experimentalLatest;
@@ -523,7 +655,7 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
     ext.latestBundleVersion = context.telemetry.properties.latestBundleVersion;
 
     if (semver.gt(latestFeedBundleVersion, latestLocalBundleVersion)) {
-      await downloadBundleAndWriteSidecar(context, effectiveBaseUrl, latestFeedBundleVersion);
+      await downloadBundleWithProgress(context, effectiveBaseUrl, latestFeedBundleVersion, 'newerVersion');
       context.telemetry.properties.extensionBundleVersionSource = 'publicFeedLatest';
       context.telemetry.properties.localBundleHashCheck = 'skipped';
       context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
@@ -537,7 +669,10 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
       const hashCheck = await verifyLocalBundleHash(context, effectiveBaseUrl, latestLocalBundleVersion);
       context.telemetry.properties.localBundleHashCheck = hashCheck;
       if (hashCheck === 'sidecarMissing' || hashCheck === 'sidecarMismatch') {
-        await downloadBundleAndWriteSidecar(context, effectiveBaseUrl, latestLocalBundleVersion);
+        // Surface a one-shot warning so the user understands *why* we're
+        // suddenly downloading on what looks like a steady-state activation.
+        notifyCorruptionDetected(latestLocalBundleVersion, describeSource(effectiveBaseUrl));
+        await downloadBundleWithProgress(context, effectiveBaseUrl, latestLocalBundleVersion, hashCheck);
         context.telemetry.properties.extensionBundleVersionSource = 'publicFeedLatest';
         context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
         context.telemetry.properties.didUpdateExtensionBundle = 'true';

--- a/apps/vs-code-designer/src/app/utils/bundleFeed.ts
+++ b/apps/vs-code-designer/src/app/utils/bundleFeed.ts
@@ -14,7 +14,7 @@ import {
 } from '../../constants';
 import { getLocalSettingsJson } from './appSettings/localSettings';
 import { downloadAndExtractDependency } from './binaries';
-import { fetchExpectedMd5 } from './integrity';
+import { fetchExpectedMd5, isMissingPackageError } from './integrity';
 import { getJsonFeed } from './feed';
 import { getGlobalSetting } from './vsCodeConfig/settings';
 import type { IActionContext } from '@microsoft/vscode-azext-utils';
@@ -38,6 +38,12 @@ export type BundleVersionSource =
   | 'experimentalLocalLatest'
   | 'publicFeedLatest'
   | 'localLatest';
+
+/**
+ * Why the extension fell back from the configured experimental source URI to
+ * the public CDN. Recorded only when a fallback actually fired.
+ */
+export type ExperimentalSourceFallbackReason = 'pinNotInIndex' | 'zip404' | 'index404' | 'networkError' | 'integrityFailure';
 
 interface ExtensionBundleBaseUrlResult {
   baseUrl: string;
@@ -239,6 +245,70 @@ async function downloadBundleAndWriteSidecar(context: IActionContext, baseUrl: s
 }
 
 /**
+ * Same as `downloadBundleAndWriteSidecar` but returns `undefined` when the
+ * configured CDN doesn't have the package (HTTP 404 / network failure) so
+ * callers can fall back to a different source. Genuine integrity failures
+ * (corrupt bytes despite valid headers) still throw — those should not be
+ * silently retried against another CDN.
+ */
+async function tryDownloadBundleAndWriteSidecar(
+  context: IActionContext,
+  baseUrl: string,
+  version: string
+): Promise<{ ok: true } | { ok: false; reason: ExperimentalSourceFallbackReason; error: unknown }> {
+  try {
+    await downloadBundleAndWriteSidecar(context, baseUrl, version);
+    return { ok: true };
+  } catch (error) {
+    if (isMissingPackageError(error)) {
+      const status = (error as { response?: { status?: number } })?.response?.status;
+      const reason: ExperimentalSourceFallbackReason = typeof status === 'number' && status === 404 ? 'zip404' : 'networkError';
+      return { ok: false, reason, error };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Fetches the index.json for the given (experimental) base URL. Returns the
+ * version array on success, `undefined` on 404 / network error so the caller
+ * can fall back. Other errors (e.g. malformed JSON) propagate.
+ */
+async function tryFetchSourceIndex(
+  context: IActionContext,
+  baseUrl: string
+): Promise<{ ok: true; versions: string[] } | { ok: false; reason: ExperimentalSourceFallbackReason; error: unknown }> {
+  const url = `${baseUrl}/ExtensionBundles/${extensionBundleId}/index.json`;
+  try {
+    const versions: string[] = await getJsonFeed(context, url);
+    return { ok: true, versions };
+  } catch (error) {
+    if (isMissingPackageError(error)) {
+      const status = (error as { response?: { status?: number } })?.response?.status;
+      const reason: ExperimentalSourceFallbackReason = typeof status === 'number' && status === 404 ? 'index404' : 'networkError';
+      return { ok: false, reason, error };
+    }
+    throw error;
+  }
+}
+
+function logExperimentalFallback(context: IActionContext, reason: ExperimentalSourceFallbackReason, detail: string, error?: unknown): void {
+  context.telemetry.properties.experimentalSourceFallback = reason;
+  context.telemetry.properties.experimentalSourceFallbackTarget = 'public';
+  if (ext.outputChannel) {
+    const message = error instanceof Error ? `${detail} (${error.message})` : detail;
+    ext.outputChannel.appendLog(
+      localize(
+        'experimentalSourceFallback',
+        'Experimental extension-bundle source could not deliver ({0}); falling back to public CDN. {1}',
+        reason,
+        message
+      )
+    );
+  }
+}
+
+/**
  * Verifies the on-disk bundle's source MD5 against what the public CDN currently
  * reports via HEAD. Used only when the experimental toggle is OFF.
  */
@@ -305,10 +375,18 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
 
     context.telemetry.properties.envVariableExtensionBundleVersion = envVarVer;
 
-    // 1. Pinned via env / local.settings.json — existing behavior.
+    // 1. Pinned via env / local.settings.json.
+    //    Use a *membership* test against the full set of local versions, not
+    //    equality with `latestLocalBundleVersion`. The runtime is happy with
+    //    any matching cached version, so re-downloading just because a newer
+    //    version also happens to be on disk is wasteful — and it's the
+    //    "later version present locally wouldn't be used" complaint.
     if (envVarVer) {
       context.telemetry.properties.extensionBundleVersionSource = 'envVar';
-      if (latestLocalBundleVersion !== '0.0.0' && semver.valid(envVarVer) && semver.eq(envVarVer, latestLocalBundleVersion)) {
+      if (semver.valid(envVarVer) && localVersions.some((v) => v === envVarVer)) {
+        ext.defaultBundleVersion = envVarVer;
+        ext.latestBundleVersion = envVarVer;
+        context.telemetry.properties.didUpdateExtensionBundle = 'false';
         return false;
       }
       await downloadBundleAndWriteSidecar(context, baseUrlInfo.baseUrl, envVarVer);
@@ -317,7 +395,11 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
       return true;
     }
 
-    // 2. Experimental toggle on — never call the public feed.
+    // 2. Experimental toggle on. Never consults the public CDN's *latest*
+    //    feed for version selection — but if the configured private source
+    //    cannot deliver the package AND we have no usable local copy, we
+    //    fall back to downloading from the public CDN as a last resort so
+    //    the dev isn't left with a non-running environment.
     if (baseUrlInfo.isExperimental) {
       const pin = baseUrlInfo.experimentalPinnedVersion;
 
@@ -330,16 +412,46 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
           context.telemetry.properties.didUpdateExtensionBundle = 'false';
           return false;
         }
+
+        // Pin not on disk: try the configured experimental source URI first
+        // (if any), then fall back to the public CDN for the same pin.
         if (baseUrlInfo.experimentalSourceUri.length > 0) {
-          await downloadBundleAndWriteSidecar(context, baseUrlInfo.experimentalSourceUri, pin);
-          ext.defaultBundleVersion = pin;
-          ext.latestBundleVersion = pin;
-          context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
-          context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
-          context.telemetry.properties.didUpdateExtensionBundle = 'true';
-          return true;
+          // Optionally probe the source's index first — this lets us
+          // distinguish "private CDN doesn't have this pin" from "private
+          // CDN is fine but the zip URL was momentarily unreachable" so the
+          // telemetry reason is accurate.
+          const indexProbe = await tryFetchSourceIndex(context, baseUrlInfo.experimentalSourceUri);
+          if (indexProbe.ok && indexProbe.versions.includes(pin)) {
+            const result = await tryDownloadBundleAndWriteSidecar(context, baseUrlInfo.experimentalSourceUri, pin);
+            if (result.ok) {
+              ext.defaultBundleVersion = pin;
+              ext.latestBundleVersion = pin;
+              context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
+              context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+              context.telemetry.properties.didUpdateExtensionBundle = 'true';
+              return true;
+            }
+            logExperimentalFallback(
+              context,
+              result.reason,
+              `Pin ${pin} listed in experimental index but its zip could not be downloaded.`,
+              result.error
+            );
+          } else if (indexProbe.ok) {
+            logExperimentalFallback(context, 'pinNotInIndex', `Pin ${pin} is not present in the experimental source index.`);
+          } else {
+            logExperimentalFallback(context, indexProbe.reason, 'Could not read the experimental source index.', indexProbe.error);
+          }
         }
-        // Pin set, not on disk, no source URI — fall through to "no pin" path below.
+
+        // Fallback: download the pin from the public CDN.
+        await downloadBundleAndWriteSidecar(context, PUBLIC_BUNDLE_BASE_URL, pin);
+        ext.defaultBundleVersion = pin;
+        ext.latestBundleVersion = pin;
+        context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
+        context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+        context.telemetry.properties.didUpdateExtensionBundle = 'true';
+        return true;
       }
 
       if (latestLocalBundleVersion !== '0.0.0') {
@@ -350,37 +462,57 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
         return false;
       }
 
+      // No pin, no local copy — try the experimental source URI for its
+      // latest. If that fails (404 / network error / empty index), fall
+      // through to the public-CDN default flow below.
       if (baseUrlInfo.experimentalSourceUri.length > 0) {
-        // Cold start with no pin: ask the experimental source for its index and grab its latest.
-        const experimentalIndexUrl = `${baseUrlInfo.experimentalSourceUri}/ExtensionBundles/${extensionBundleId}/index.json`;
-        const experimentalFeed: string[] = await getJsonFeed(context, experimentalIndexUrl);
-        const experimentalLatest = pickLatestVersion(experimentalFeed);
-        if (experimentalLatest === '0.0.0') {
-          throw new Error(
-            localize(
-              'experimentalBundleEmpty',
-              'Experimental extension-bundle source "{0}" returned no versions.',
-              baseUrlInfo.experimentalSourceUri
-            )
-          );
+        const indexProbe = await tryFetchSourceIndex(context, baseUrlInfo.experimentalSourceUri);
+        if (indexProbe.ok) {
+          const experimentalLatest = pickLatestVersion(indexProbe.versions);
+          if (experimentalLatest !== '0.0.0') {
+            const result = await tryDownloadBundleAndWriteSidecar(context, baseUrlInfo.experimentalSourceUri, experimentalLatest);
+            if (result.ok) {
+              ext.defaultBundleVersion = experimentalLatest;
+              ext.latestBundleVersion = experimentalLatest;
+              context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
+              context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
+              context.telemetry.properties.didUpdateExtensionBundle = 'true';
+              return true;
+            }
+            logExperimentalFallback(
+              context,
+              result.reason,
+              `Latest ${experimentalLatest} from experimental source failed to download.`,
+              result.error
+            );
+          } else {
+            logExperimentalFallback(context, 'index404', 'Experimental source index returned no versions.');
+          }
+        } else {
+          logExperimentalFallback(context, indexProbe.reason, 'Could not read the experimental source index.', indexProbe.error);
         }
-        await downloadBundleAndWriteSidecar(context, baseUrlInfo.experimentalSourceUri, experimentalLatest);
-        ext.defaultBundleVersion = experimentalLatest;
-        ext.latestBundleVersion = experimentalLatest;
-        context.telemetry.properties.extensionBundleVersionSource = 'experimentalFirstDownload';
-        context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
-        context.telemetry.properties.didUpdateExtensionBundle = 'true';
-        return true;
       }
-      // Toggle is on but no pin, no local, no experimental URI — fall through to public-feed flow
-      // so the dev isn't dead-in-the-water just because they enabled the toggle without configuring
-      // anything else.
+      // Toggle is on but no pin, no local, and the experimental URI either
+      // wasn't set or couldn't deliver — fall through to public-feed flow
+      // so the dev isn't dead-in-the-water.
       context.telemetry.properties.experimentalFellThroughToPublic = 'true';
     }
 
     // 3. Default flow: use latest local if intact; otherwise re-download from CDN.
+    //    If we got here via the experimental fall-through, force the public CDN —
+    //    using the (broken) experimental baseUrl would defeat the whole point of
+    //    the fallback.
+    const fellThroughFromExperimental = baseUrlInfo.isExperimental;
+    const effectiveBaseUrl = fellThroughFromExperimental ? PUBLIC_BUNDLE_BASE_URL : baseUrlInfo.baseUrl;
+
     let latestFeedBundleVersion = '0.0.0';
-    const feedVersions: string[] = await getWorkflowBundleFeed(context);
+    let feedVersions: string[];
+    if (fellThroughFromExperimental) {
+      const publicIndexUrl = `${PUBLIC_BUNDLE_BASE_URL}/ExtensionBundles/${extensionBundleId}/index.json`;
+      feedVersions = await getJsonFeed(context, publicIndexUrl);
+    } else {
+      feedVersions = await getWorkflowBundleFeed(context);
+    }
     latestFeedBundleVersion = pickLatestVersion(feedVersions);
 
     context.telemetry.properties.latestBundleVersion = semver.gt(latestFeedBundleVersion, latestLocalBundleVersion)
@@ -391,7 +523,7 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
     ext.latestBundleVersion = context.telemetry.properties.latestBundleVersion;
 
     if (semver.gt(latestFeedBundleVersion, latestLocalBundleVersion)) {
-      await downloadBundleAndWriteSidecar(context, baseUrlInfo.baseUrl, latestFeedBundleVersion);
+      await downloadBundleAndWriteSidecar(context, effectiveBaseUrl, latestFeedBundleVersion);
       context.telemetry.properties.extensionBundleVersionSource = 'publicFeedLatest';
       context.telemetry.properties.localBundleHashCheck = 'skipped';
       context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
@@ -402,10 +534,10 @@ export async function downloadExtensionBundle(context: IActionContext): Promise<
     // Local is at least as new as the feed — verify the on-disk bundle's source MD5
     // and re-download if it's missing or has drifted (e.g. CDN republished the same version).
     if (latestLocalBundleVersion !== '0.0.0') {
-      const hashCheck = await verifyLocalBundleHash(context, baseUrlInfo.baseUrl, latestLocalBundleVersion);
+      const hashCheck = await verifyLocalBundleHash(context, effectiveBaseUrl, latestLocalBundleVersion);
       context.telemetry.properties.localBundleHashCheck = hashCheck;
       if (hashCheck === 'sidecarMissing' || hashCheck === 'sidecarMismatch') {
-        await downloadBundleAndWriteSidecar(context, baseUrlInfo.baseUrl, latestLocalBundleVersion);
+        await downloadBundleAndWriteSidecar(context, effectiveBaseUrl, latestLocalBundleVersion);
         context.telemetry.properties.extensionBundleVersionSource = 'publicFeedLatest';
         context.telemetry.measurements.downloadExtensionBundleDuration = (Date.now() - downloadExtensionBundleStartTime) / 1000;
         context.telemetry.properties.didUpdateExtensionBundle = 'true';

--- a/apps/vs-code-designer/src/app/utils/integrity.ts
+++ b/apps/vs-code-designer/src/app/utils/integrity.ts
@@ -1,0 +1,177 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * vscode-free integrity helpers. Importable from both the extension host
+ * (binaries.ts) and from ExTester / Mocha tests that cannot pull in the
+ * `vscode` module.
+ */
+import axios from 'axios';
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+
+/**
+ * Error thrown when a downloaded file fails integrity verification
+ * (size or MD5 mismatch against the response headers).
+ */
+export class DownloadIntegrityError extends Error {
+  constructor(
+    public readonly url: string,
+    public readonly reason: 'size' | 'md5',
+    public readonly expected: string,
+    public readonly actual: string
+  ) {
+    super(`Download integrity check failed for ${url}: ${reason} mismatch (expected ${expected}, got ${actual}).`);
+    this.name = 'DownloadIntegrityError';
+  }
+}
+
+export interface DownloadAttemptResult {
+  expectedSize?: number;
+  actualSize: number;
+  expectedMd5?: string;
+  actualMd5: string;
+}
+
+export const DEFAULT_DOWNLOAD_MAX_ATTEMPTS = 3;
+
+/**
+ * Optional callbacks the extension host plugs in so log + telemetry stays in
+ * its own layer; in tests we leave these undefined.
+ */
+export interface DownloadHooks {
+  onAttempt?: (attempt: number, error: unknown, willRetry: boolean) => void;
+  onSuccess?: (attempt: number, result: DownloadAttemptResult, durationMs: number) => void;
+}
+
+/**
+ * Streams a file from `url` to `destPath`, verifying integrity against
+ * `Content-Length` and `Content-MD5` response headers when present.
+ *
+ * Azure Blob Storage (which backs cdn.functions.azure.com) sets both headers
+ * on upload, so this catches CDN-edge truncation/corruption end-to-end without
+ * any publishing-pipeline changes.
+ *
+ * Retries on network errors and integrity failures with exponential backoff.
+ */
+export async function downloadFileWithVerification(
+  url: string,
+  destPath: string,
+  options: { maxAttempts?: number; hooks?: DownloadHooks } = {}
+): Promise<DownloadAttemptResult> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_DOWNLOAD_MAX_ATTEMPTS;
+  const hooks = options.hooks ?? {};
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const attemptStart = Date.now();
+    try {
+      const result = await downloadFileAttempt(url, destPath);
+      hooks.onSuccess?.(attempt, result, Date.now() - attemptStart);
+      return result;
+    } catch (error) {
+      lastError = error;
+      try {
+        if (fs.existsSync(destPath)) {
+          fs.rmSync(destPath, { force: true });
+        }
+      } catch {
+        // best-effort cleanup
+      }
+
+      const isRetryable = isRetryableDownloadError(error);
+      const willRetry = isRetryable && attempt < maxAttempts;
+      hooks.onAttempt?.(attempt, error, willRetry);
+
+      if (!willRetry) {
+        throw error;
+      }
+      await delay(1000 * 2 ** (attempt - 1));
+    }
+  }
+  throw lastError;
+}
+
+function downloadFileAttempt(url: string, destPath: string): Promise<DownloadAttemptResult> {
+  return new Promise<DownloadAttemptResult>((resolve, reject) => {
+    axios
+      .get(url, { responseType: 'stream' })
+      .then((response) => {
+        const headers = response.headers ?? {};
+        const contentLengthRaw = headers['content-length'] ?? headers['Content-Length'];
+        const expectedSize = contentLengthRaw === undefined ? undefined : Number.parseInt(String(contentLengthRaw), 10);
+        const expectedMd5Raw = headers['content-md5'] ?? headers['Content-MD5'];
+        const expectedMd5 = typeof expectedMd5Raw === 'string' && expectedMd5Raw.length > 0 ? expectedMd5Raw : undefined;
+
+        const writer = fs.createWriteStream(destPath);
+        const hash = createHash('md5');
+        let actualSize = 0;
+        let settled = false;
+
+        const settle = (fn: () => void) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          fn();
+        };
+
+        response.data.on('data', (chunk: Buffer) => {
+          actualSize += chunk.length;
+          hash.update(new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+        });
+        response.data.on('error', (err: Error) => settle(() => reject(err)));
+        writer.on('error', (err: Error) => settle(() => reject(err)));
+        writer.on('finish', () =>
+          settle(() => {
+            if (expectedSize !== undefined && Number.isFinite(expectedSize) && actualSize !== expectedSize) {
+              reject(new DownloadIntegrityError(url, 'size', String(expectedSize), String(actualSize)));
+              return;
+            }
+            const actualMd5 = hash.digest('base64');
+            if (expectedMd5 && actualMd5 !== expectedMd5) {
+              reject(new DownloadIntegrityError(url, 'md5', expectedMd5, actualMd5));
+              return;
+            }
+            resolve({ expectedSize, actualSize, expectedMd5, actualMd5 });
+          })
+        );
+
+        response.data.pipe(writer);
+      })
+      .catch((err) => reject(err));
+  });
+}
+
+export function isRetryableDownloadError(error: unknown): boolean {
+  if (error instanceof DownloadIntegrityError) {
+    return true;
+  }
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  if (typeof status === 'number') {
+    return status >= 500 && status < 600;
+  }
+  return true;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Issues a HEAD request against `url` and returns the published `Content-MD5`
+ * (base64) value, if any. Returns `undefined` when the header is missing.
+ * Throws when the request itself fails so callers can decide whether to
+ * fall back gracefully.
+ */
+export async function fetchExpectedMd5(url: string): Promise<string | undefined> {
+  const response = await axios.head(url);
+  const headers = response.headers ?? {};
+  const expectedMd5Raw = headers['content-md5'] ?? headers['Content-MD5'];
+  if (typeof expectedMd5Raw === 'string' && expectedMd5Raw.length > 0) {
+    return expectedMd5Raw;
+  }
+  return undefined;
+}

--- a/apps/vs-code-designer/src/app/utils/integrity.ts
+++ b/apps/vs-code-designer/src/app/utils/integrity.ts
@@ -175,3 +175,26 @@ export async function fetchExpectedMd5(url: string): Promise<string | undefined>
   }
   return undefined;
 }
+
+/**
+ * Returns true for errors that indicate "the configured CDN does not have the
+ * package right now" — HTTP 404 / 4xx, plus the common Node network failure
+ * codes (no DNS, refused connection, timeout). Genuine integrity failures
+ * (corrupt bytes returned with the right size/headers) and 5xx errors are NOT
+ * "missing package" — they're transient or actively wrong, and the caller
+ * should retry / surface them rather than silently fall back.
+ */
+export function isMissingPackageError(error: unknown): boolean {
+  if (error instanceof DownloadIntegrityError) {
+    return false;
+  }
+  const status = (error as { response?: { status?: number } })?.response?.status;
+  if (typeof status === 'number') {
+    return status >= 400 && status < 500;
+  }
+  const code = (error as { code?: string })?.code;
+  if (typeof code === 'string') {
+    return code === 'ENOTFOUND' || code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'EAI_AGAIN' || code === 'ECONNRESET';
+  }
+  return false;
+}

--- a/apps/vs-code-designer/src/constants.ts
+++ b/apps/vs-code-designer/src/constants.ts
@@ -279,6 +279,9 @@ export const dotNetBinaryPathSettingKey = 'dotnetBinaryPath';
 export const nodeJsBinaryPathSettingKey = 'nodeJsBinaryPath';
 export const funcCoreToolsBinaryPathSettingKey = 'funcCoreToolsBinaryPath';
 export const dependencyTimeoutSettingKey = 'dependencyTimeout';
+export const useExperimentalExtensionBundleSettingKey = 'useExperimentalExtensionBundle';
+export const experimentalExtensionBundleSourceUriSettingKey = 'experimentalExtensionBundleSourceUri';
+export const experimentalExtensionBundleVersionSettingKey = 'experimentalExtensionBundleVersion';
 export const unitTestExplorer = 'unitTestExplorer';
 export const verifyConnectionKeysSetting = 'verifyConnectionKeys';
 export const useSmbDeployment = 'useSmbDeploymentForHybrid';
@@ -287,6 +290,7 @@ export const onStartLanguageServerProtocol = 'onStartLanguageServerProtocol';
 // host.json
 export const extensionBundleId = 'Microsoft.Azure.Functions.ExtensionBundle.Workflows';
 export const targetBundleKey = 'FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI';
+export const bundleSourceMd5SidecarFile = '.bundle-source-md5';
 
 // local.settings.json
 export const localEmulatorConnectionString = 'UseDevelopmentStorage=true';

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -1041,17 +1041,17 @@
           "azureLogicAppsStandard.useExperimentalExtensionBundle": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Experimental: when enabled, the Logic Apps extension bundle is sourced from local disk and (if missing) `#azureLogicAppsStandard.experimentalExtensionBundleSourceUri#`, instead of the public CDN. The public CDN feed is **not** consulted for 'latest' while this is on. Use this to test preview bundles that have not yet been published to `cdn.functions.azure.com`."
+            "markdownDescription": "Experimental master opt-in. When enabled, the Logic Apps extension bundle is sourced from local disk first, then from `#azureLogicAppsStandard.experimentalExtensionBundleSourceUri#` if configured. The public CDN's *latest* feed is **not** consulted for version selection while this is on. If the configured private source cannot deliver the requested package and no usable local copy exists, the extension automatically falls back to a single download from the public CDN so the environment stays runnable. **The other two `experimental*` settings have no effect while this is `false`.** Use this to test preview bundles that have not yet been published to `cdn.functions.azure.com`."
           },
           "azureLogicAppsStandard.experimentalExtensionBundleSourceUri": {
             "type": "string",
             "default": "",
-            "markdownDescription": "Experimental: alternative base URL for the Logic Apps extension bundle (mirrors the shape of `FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI`, e.g. `https://my-private-cdn/public`). Only used when `#azureLogicAppsStandard.useExperimentalExtensionBundle#` is enabled and the requested version is not already on disk."
+            "markdownDescription": "Experimental: alternative base URL for the Logic Apps extension bundle (mirrors the shape of `FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI`, e.g. `https://my-private-cdn/public`). **Only honored when `#azureLogicAppsStandard.useExperimentalExtensionBundle#` is `true`.** If the configured URL cannot deliver the requested bundle (HTTP 404, unreachable, or missing version), the extension automatically falls back to the public Azure CDN to avoid leaving you with a broken environment; check the output channel for the `experimentalSourceFallback` reason."
           },
           "azureLogicAppsStandard.experimentalExtensionBundleVersion": {
             "type": "string",
             "default": "",
-            "markdownDescription": "Experimental: optional pinned version (for example `1.21.0-preview`) to use from local disk when `#azureLogicAppsStandard.useExperimentalExtensionBundle#` is enabled. If empty, the highest local version is used. If set but missing from disk and a source URI is configured, the pinned version is downloaded once."
+            "markdownDescription": "Experimental: optional pinned version (for example `1.21.0-preview`). **Only honored when `#azureLogicAppsStandard.useExperimentalExtensionBundle#` is `true`.** While set, no 'latest' feed is consulted; the version is fetched from the configured source URL with the same public-CDN fallback as `#azureLogicAppsStandard.experimentalExtensionBundleSourceUri#`. If empty, the highest local version is used."
           }
         }
       }

--- a/apps/vs-code-designer/src/package.json
+++ b/apps/vs-code-designer/src/package.json
@@ -1037,6 +1037,21 @@
             "type": "string",
             "default": "",
             "markdownDescription": "Absolute path to the .nupkg file."
+          },
+          "azureLogicAppsStandard.useExperimentalExtensionBundle": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Experimental: when enabled, the Logic Apps extension bundle is sourced from local disk and (if missing) `#azureLogicAppsStandard.experimentalExtensionBundleSourceUri#`, instead of the public CDN. The public CDN feed is **not** consulted for 'latest' while this is on. Use this to test preview bundles that have not yet been published to `cdn.functions.azure.com`."
+          },
+          "azureLogicAppsStandard.experimentalExtensionBundleSourceUri": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Experimental: alternative base URL for the Logic Apps extension bundle (mirrors the shape of `FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI`, e.g. `https://my-private-cdn/public`). Only used when `#azureLogicAppsStandard.useExperimentalExtensionBundle#` is enabled and the requested version is not already on disk."
+          },
+          "azureLogicAppsStandard.experimentalExtensionBundleVersion": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Experimental: optional pinned version (for example `1.21.0-preview`) to use from local disk when `#azureLogicAppsStandard.useExperimentalExtensionBundle#` is enabled. If empty, the highest local version is used. If set but missing from disk and a source URI is configured, the pinned version is downloaded once."
           }
         }
       }

--- a/apps/vs-code-designer/src/test/ui/SKILL.md
+++ b/apps/vs-code-designer/src/test/ui/SKILL.md
@@ -64,6 +64,7 @@ Run `npx biome check --write <files>` and `npx tsup --config tsup.e2e.test.confi
 | File | Purpose |
 |------|---------|
 | `src/test/ui/nonLogicAppStartup.test.ts` | Plain-folder startup regression test. Phase 4.0 |
+| `src/test/ui/bundleCdnHealth.test.ts` | CDN integrity probe (`Content-Length` + `Content-MD5` on Microsoft.Azure.Functions.ExtensionBundle.Workflows). Pure Mocha — runs without VS Code. Phase 4.11 / `E2E_MODE=bundleintegrityonly`. |
 | `src/test/ui/createWorkspace.test.ts` | Create Workspace wizard tests (~4359 lines). Phase 4.1 |
 | `src/test/ui/designerActions.test.ts` | Designer full lifecycle tests (~2647 lines). Phase 4.2 |
 | `src/test/ui/designerOpen.test.ts` | Designer open tests (~1100 lines). Deprecated — Phase 4.2 now uses `designerActions.test.ts` only |
@@ -124,6 +125,7 @@ pnpm run test:ui        # Runs node src/test/ui/run-e2e.js
 | (unset) | Runs Phase 4.0 (non-Logic-App startup), Phase 4.1 (createWorkspace), then later designer/conversion phases |
 | `nonlogicappstartup` | Runs only Phase 4.0 with minimal settings and no runtime dependency paths |
 | `designeronly` | Skips Phase 4.1, runs Phase 4.2 using workspaces from a previous Phase 4.1 run |
+| `bundleintegrityonly` | Runs Phase 4.11 (`bundleCdnHealth.test.ts`) — pure-Mocha probe of `cdn.functions.azure.com` integrity headers. No VS Code session, no compiled extension required (only `npx tsup --config tsup.e2e.test.config.ts`). Bundled into the `independentonly` shard for CI. |
 
 **IMPORTANT**: `E2E_MODE=designeronly` requires that Phase 4.1 has been run previously in the same session and workspaces still exist on disk. If the previous run's `after()` hook cleaned up workspaces, Phase 4.2 tests will fail with "Missing workspace directories" errors.
 

--- a/apps/vs-code-designer/src/test/ui/bundleCdnHealth.test.ts
+++ b/apps/vs-code-designer/src/test/ui/bundleCdnHealth.test.ts
@@ -1,0 +1,175 @@
+/// <reference types="mocha" />
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * End-to-end CDN health probe for Microsoft.Azure.Functions.ExtensionBundle.Workflows.
+ *
+ * Runs as a plain Mocha suite (no ExTester / VS Code) so it stays fast and
+ * doesn't require an X server. The test verifies two things against the
+ * live `cdn.functions.azure.com` endpoint:
+ *
+ *   1. The CDN still emits the headers we depend on for client-side
+ *      integrity verification (Content-Length + Content-MD5). If the CDN
+ *      stops sending these — or changes their format — every Phase-1
+ *      download verification turns into a no-op without anyone noticing.
+ *      This test fails loudly so the regression is caught at PR time.
+ *
+ *   2. A small JSON file (`index.json`, a few KB) can be downloaded
+ *      end-to-end through `downloadFileWithVerification` from
+ *      `app/utils/integrity.ts`. We use this rather than the full bundle
+ *      zip (~250 MB) to keep the test fast.
+ *
+ * Triggered by E2E_MODE=bundleintegrityonly via run-e2e.js. Also wired into
+ * the `independentonly` shard.
+ */
+
+import * as assert from 'assert';
+import axios from 'axios';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadFileWithVerification, fetchExpectedMd5, DEFAULT_DOWNLOAD_MAX_ATTEMPTS } from '../../app/utils/integrity';
+
+const PUBLIC_BUNDLE_BASE_URL = 'https://cdn.functions.azure.com/public';
+const EXTENSION_BUNDLE_ID = 'Microsoft.Azure.Functions.ExtensionBundle.Workflows';
+const INDEX_URL = `${PUBLIC_BUNDLE_BASE_URL}/ExtensionBundles/${EXTENSION_BUNDLE_ID}/index.json`;
+
+const TEST_TIMEOUT = 60_000;
+// Accept a base64 MD5 like "K2WG08BmGeB5pCBJZ/uHwg==". 24 chars including a
+// trailing "==" pad is the canonical shape for a 16-byte MD5.
+const BASE64_MD5_PATTERN = /^[A-Za-z0-9+/]{22}==$/;
+
+interface BundleIndexFeed extends Array<string> {}
+
+async function fetchBundleIndex(): Promise<BundleIndexFeed> {
+  const response = await axios.get<BundleIndexFeed>(INDEX_URL, { timeout: 30_000 });
+  return response.data;
+}
+
+function pickLatestVersion(feed: BundleIndexFeed): string {
+  if (!Array.isArray(feed) || feed.length === 0) {
+    throw new Error('Bundle index feed contained no versions');
+  }
+  // Sort numerically by major.minor.patch so we pick the actual newest version
+  // rather than relying on lexicographic order (which would put 1.9.0 > 1.10.0).
+  const sorted = [...feed].sort((a, b) => {
+    const pa = a.split('.').map((n) => Number.parseInt(n, 10));
+    const pb = b.split('.').map((n) => Number.parseInt(n, 10));
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+      const da = pa[i] ?? 0;
+      const db = pb[i] ?? 0;
+      if (da !== db) {
+        return da - db;
+      }
+    }
+    return 0;
+  });
+  return sorted[sorted.length - 1];
+}
+
+function buildBundleZipUrl(version: string): string {
+  return `${PUBLIC_BUNDLE_BASE_URL}/ExtensionBundles/${EXTENSION_BUNDLE_ID}/${version}/${EXTENSION_BUNDLE_ID}.${version}_any-any.zip`;
+}
+
+describe('Bundle CDN integrity headers (live)', function () {
+  this.timeout(TEST_TIMEOUT);
+
+  let latestVersion: string;
+  let zipUrl: string;
+  let scratchDir: string;
+
+  before(async () => {
+    const feed = await fetchBundleIndex();
+    latestVersion = pickLatestVersion(feed);
+    zipUrl = buildBundleZipUrl(latestVersion);
+    scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'la-e2e-bundle-cdn-'));
+    // eslint-disable-next-line no-console
+    console.log(`  [bundleCdnHealth] probing ${zipUrl}`);
+  });
+
+  after(() => {
+    if (scratchDir && fs.existsSync(scratchDir)) {
+      fs.rmSync(scratchDir, { recursive: true, force: true });
+    }
+  });
+
+  it('HEAD on the latest bundle zip returns Content-Length + Content-MD5', async () => {
+    const response = await axios.head(zipUrl, { timeout: 30_000 });
+    const headers = response.headers as Record<string, string | undefined>;
+
+    const contentLength = headers['content-length'];
+    assert.ok(contentLength, 'CDN response missing Content-Length header');
+    const lengthValue = Number(contentLength);
+    assert.ok(Number.isFinite(lengthValue) && lengthValue > 0, `Content-Length not a positive integer: ${contentLength}`);
+
+    const contentMd5 = headers['content-md5'];
+    assert.ok(contentMd5, 'CDN response missing Content-MD5 header — Phase 1 hash verification cannot work without it');
+    assert.ok(BASE64_MD5_PATTERN.test(contentMd5), `Content-MD5 is not a valid 16-byte base64 MD5: ${contentMd5}`);
+  });
+
+  it('fetchExpectedMd5 returns a valid base64 MD5 for the bundle zip', async () => {
+    const md5 = await fetchExpectedMd5(zipUrl);
+    assert.ok(md5, 'fetchExpectedMd5 returned undefined for live bundle zip');
+    assert.ok(BASE64_MD5_PATTERN.test(md5 as string), `fetchExpectedMd5 returned non-base64 value: ${md5}`);
+  });
+
+  it('downloadFileWithVerification successfully downloads index.json with verification', async () => {
+    const destPath = path.join(scratchDir, 'index.json');
+    const result = await downloadFileWithVerification(INDEX_URL, destPath, {
+      maxAttempts: DEFAULT_DOWNLOAD_MAX_ATTEMPTS,
+    });
+
+    assert.ok(fs.existsSync(destPath), 'index.json was not written to disk');
+    const stat = fs.statSync(destPath);
+    assert.ok(stat.size > 0, 'index.json on disk has zero bytes');
+
+    // Result captures actual bytes + MD5; only verify expected against actual
+    // when the response actually carried those headers (some CDN endpoints
+    // omit Content-MD5 on small JSON, in which case this is a no-op).
+    if (result.expectedSize !== undefined) {
+      assert.strictEqual(result.actualSize, result.expectedSize, 'actualSize !== expectedSize');
+    }
+    if (result.expectedMd5 !== undefined) {
+      assert.strictEqual(result.actualMd5, result.expectedMd5, 'actualMd5 !== expectedMd5');
+    }
+  });
+});
+
+describe('Bundle CDN integrity headers (experimental settings smoke)', function () {
+  this.timeout(TEST_TIMEOUT);
+
+  it('honors FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI env var override (HEAD against the override URL)', async () => {
+    // The extension's `getExtensionBundleBaseUrl()` reads:
+    //   1) local.settings.json
+    //   2) process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI
+    //   3) experimental VS Code setting
+    //   4) public default
+    // The helper itself imports `vscode`, so we can't run it from this
+    // pure-Mocha test. Instead we replicate the contract that `binaries.ts`
+    // and `bundleFeed.ts` rely on: that the env var takes precedence over
+    // the public default.
+    const before = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+    try {
+      process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI = PUBLIC_BUNDLE_BASE_URL;
+      // If a dev points the env var at the public CDN, we should still get
+      // a healthy index.json — confirms the URL shape.
+      const response = await axios.get(
+        `${process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI}/ExtensionBundles/${EXTENSION_BUNDLE_ID}/index.json`,
+        {
+          timeout: 30_000,
+        }
+      );
+      assert.strictEqual(response.status, 200);
+    } finally {
+      if (before === undefined) {
+        delete process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
+      } else {
+        process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI = before;
+      }
+    }
+  });
+});

--- a/apps/vs-code-designer/src/test/ui/run-e2e.js
+++ b/apps/vs-code-designer/src/test/ui/run-e2e.js
@@ -261,6 +261,33 @@ async function parallelLimit(taskFns, limit) {
 }
 
 async function main() {
+  // Fast path: bundleintegrityonly is a pure-Node Mocha probe that needs
+  // neither the built extension (dist/package.json) nor ExTester / VS Code.
+  // Short-circuit before any of those checks so the phase can run on a
+  // fresh checkout (or any shard) without first running the extension build.
+  const earlyMode = (process.env.E2E_MODE || 'full').toLowerCase();
+  if (earlyMode === 'bundleintegrityonly') {
+    const outTestDir = path.resolve(__dirname, '..', '..', '..', 'out', 'test');
+    const file = path.join(outTestDir, 'bundleCdnHealth.test.js').replace(/\\/g, '/');
+    if (!fs.existsSync(file)) {
+      console.error(`\n✖ Compiled test not found: ${file}\n  Run: npx tsup --config tsup.e2e.test.config.ts`);
+      process.exit(2);
+    }
+    try {
+      delete require.cache[require.resolve(file)];
+    } catch {
+      /* ignore */
+    }
+    const Mocha = require('mocha');
+    const mocha = new Mocha({ color: true, timeout: 60_000, reporter: 'spec' });
+    mocha.addFile(file);
+    const exit = await new Promise((resolve) => {
+      mocha.run((failures) => resolve(failures > 0 ? 1 : 0));
+    });
+    console.log(`\n=== bundleintegrityonly exit code: ${exit} ===`);
+    process.exit(exit);
+  }
+
   const { ExTester } = require('vscode-extension-tester');
 
   // ------------------------------------------------------------------
@@ -775,7 +802,14 @@ async function main() {
   const settingsFile = path.join(projectDir, 'out', 'test', 'vscode-settings.json');
   fs.mkdirSync(path.dirname(settingsFile), { recursive: true });
 
-  const writeTestSettings = ({ validateDependencies = false, autoStartDesignTime = true, includeRuntimeDependencyPaths = true } = {}) => {
+  const writeTestSettings = ({
+    validateDependencies = false,
+    autoStartDesignTime = true,
+    includeRuntimeDependencyPaths = true,
+    useExperimentalBundle = false,
+    experimentalBundleSourceUri = '',
+    experimentalBundleVersion = '',
+  } = {}) => {
     const settings = {
       'extensions.autoUpdate': false,
       'extensions.autoCheckUpdates': false,
@@ -813,6 +847,13 @@ async function main() {
       // the generated task chain has started instead of waiting the default
       // 60 s. Other phases never reach pickProcess so this is harmless.
       'azureLogicAppsStandard.pickProcessTimeout': 15,
+      // Experimental-bundle opt-ins. Off by default for every phase so the
+      // standard CDN flow continues to be tested. The bundleintegrityonly
+      // phase or any future phase that wants to test a private bundle can
+      // flip these via writeTestSettings options.
+      'azureLogicAppsStandard.useExperimentalExtensionBundle': useExperimentalBundle,
+      'azureLogicAppsStandard.experimentalExtensionBundleSourceUri': experimentalBundleSourceUri,
+      'azureLogicAppsStandard.experimentalExtensionBundleVersion': experimentalBundleVersion,
     };
     if (includeRuntimeDependencyPaths) {
       const { depsRoot, funcBinary, dotnetBinary, nodeBinary } = getRuntimeDependencyPaths();
@@ -907,6 +948,12 @@ async function main() {
 
   const phase10ModernFiles = [testFile('codefulDebugTasksModern.test.js')];
   const phase10LegacyFiles = [testFile('codefulDebugTasksLegacy.test.js')];
+
+  // Phase 4.11 — Bundle CDN integrity probe. Pure Mocha (no ExTester / VS Code).
+  // Verifies that cdn.functions.azure.com still emits Content-Length +
+  // Content-MD5 headers we depend on for download integrity verification, and
+  // does a small live download through the verifier helper.
+  const phaseBundleIntegrityFiles = [testFile('bundleCdnHealth.test.js')];
 
   // ------------------------------------------------------------------
   // Per-scenario inventory (Phase A scaffold).
@@ -1268,6 +1315,34 @@ async function main() {
     const code = await phaseTester.runTests(files, phaseRunOptions);
     console.log(`  ${phaseName} exit code: ${code}`);
     return code;
+  };
+
+  // Runs Mocha against compiled test files directly, without spawning a VS Code
+  // session. Used for the bundle CDN integrity probe, which is a pure Node
+  // test (HTTP HEAD + small download) and does not need ExTester.
+  const runMochaPhase = async (phaseName, files) => {
+    console.log(`\n=== ${phaseName} (Mocha-only, no VS Code) ===`);
+    console.log(`  Files: ${files.join(', ')}`);
+    for (const file of files) {
+      try {
+        delete require.cache[require.resolve(file)];
+      } catch {
+        /* ignore */
+      }
+    }
+    // Lazy-require Mocha so other phases don't pay the cost.
+    const Mocha = require('mocha');
+    const mocha = new Mocha({ color: true, timeout: 60_000, reporter: 'spec' });
+    for (const file of files) {
+      mocha.addFile(file);
+    }
+    return await new Promise((resolve) => {
+      mocha.run((failures) => {
+        const code = failures > 0 ? 1 : 0;
+        console.log(`  ${phaseName} exit code: ${code}`);
+        resolve(code);
+      });
+    });
   };
 
   const configureCodefulRecorderEnvironment = () => {
@@ -1730,6 +1805,14 @@ namespace ${namespaceName}
       process.exit(phase10Exit);
     }
 
+    if (e2eMode === 'bundleintegrityonly') {
+      // Pure Node Mocha — no ExTester, no VS Code session needed. Probes
+      // cdn.functions.azure.com to confirm the integrity headers we depend
+      // on are still emitted.
+      const exit = await runMochaPhase('Phase 4.11: bundleCdnHealth', phaseBundleIntegrityFiles);
+      process.exit(exit);
+    }
+
     if (e2eMode === 'nonlogicappstartup') {
       // Startup regression test: intentionally omit runtime dependency paths to
       // exercise extension activation in a plain, non-Logic-App folder.
@@ -1926,8 +2009,12 @@ namespace ${namespaceName}
       process.env.LA_E2E_LEGACY_PROJECT_DIR = legacyDir;
       exits.push(await runPhase('Phase 4.8b: conversionCreate', phase8bFiles, { resources: [legacyDir] }));
 
+      // Phase 4.11: bundleCdnHealth — pure Mocha, no VS Code. Confirms the
+      // CDN still emits Content-Length + Content-MD5 headers we rely on.
+      exits.push(await runMochaPhase('Phase 4.11: bundleCdnHealth', phaseBundleIntegrityFiles));
+
       const finalExit = Math.max(...exits);
-      console.log(`\n=== Independent shard results: 4.0=${exits[0]}, 4.8b=${exits[1]} → exit ${finalExit} ===`);
+      console.log(`\n=== Independent shard results: 4.0=${exits[0]}, 4.8b=${exits[1]}, 4.11=${exits[2]} → exit ${finalExit} ===`);
       process.exit(finalExit);
     }
 

--- a/docs/ai-setup/packages/vs-code-designer.md
+++ b/docs/ai-setup/packages/vs-code-designer.md
@@ -142,6 +142,7 @@ Each test runs in its own fresh VS Code session to avoid workspace-switch conten
 | 4.5 | designerViewExtended.test.ts | Parallel branches + run-after (ADO #10109401) |
 | 4.6 | keyboardNavigation.test.ts | Ctrl+Up/Down + Ctrl+Alt+P / Ctrl+Shift+P hotkey contract |
 | 4.7 | dataMapper.test.ts, demo, smoke, standalone | Data Mapper + generic tests |
+| 4.11 | bundleCdnHealth.test.ts | CDN integrity headers probe (`Content-Length` / `Content-MD5` on the Workflows extension bundle). Pure Mocha — no VS Code session. |
 
 ### Shared Helper Modules
 
@@ -192,9 +193,10 @@ $env:E2E_MODE = "newtestsonly"            # Phases 4.3-4.6 only (requires prior 
 $env:E2E_MODE = "conversiononly"          # Phases 4.8a-e only (requires prior 4.1 manifest)
 $env:E2E_MODE = "conversioncreateonly"    # Phase 4.8b only (builds own legacy fixture)
 $env:E2E_MODE = "nonlogicappstartup"      # Phase 4.0 only
+$env:E2E_MODE = "bundleintegrityonly"     # Phase 4.11 — pure-Mocha CDN integrity probe (no VS Code)
 
 # CI matrix shard modes (each runs on its own GitHub Actions runner):
-$env:E2E_MODE = "independentonly"         # 4.0 + 4.8b — no Phase 4.1 dep
+$env:E2E_MODE = "independentonly"         # 4.0 + 4.8b + 4.11 — no Phase 4.1 dep
 $env:E2E_MODE = "createplusdesigner"      # 4.1 → 4.2, 4.7
 $env:E2E_MODE = "createplusnewtests"      # 4.1 → 4.3, 4.4, 4.5, 4.6
 $env:E2E_MODE = "createplusconversion"    # 4.1 → 4.8a, 4.8c, 4.8d, 4.8e


### PR DESCRIPTION
## Why

The Logic Apps VS Code extension downloads `Microsoft.Azure.Functions.ExtensionBundle.Workflows` from a CDN at activation. When the CDN occasionally returns a truncated zip, the extension would happily cache the partial file and then fail later in opaque ways. There was also no way to test against an unreleased bundle locally, no fallback when a private/experimental CDN is misconfigured, and no user-visible signal that anything was happening when activation stalled on a download.

## What changed

**Integrity verification (`integrity.ts`)**
- New `downloadFileWithVerification` streams the response while tracking byte count, computing MD5, and validating both against `Content-Length` / `Content-MD5` response headers; retries up to 3 times on mismatch.
- New `verifyLocalBundleHash` reads a `.bundle-source-md5` sidecar written at download time and compares it against a fresh HEAD against the CDN, returning `match` / `sidecarMissing` / `sidecarMismatch` / `headUnavailable`.
- New `isMissingPackageError` distinguishes "package not at this URL" (4xx, network) from "CDN is sick" (5xx) so we only fall back when the source genuinely cannot deliver.

**Experimental bundle settings (`package.json` + `bundleFeed.ts`)**
- Added three VS Code settings: `useExperimentalExtensionBundle` (master toggle), `experimentalExtensionBundleSourceUri`, and `experimentalExtensionBundleVersion`. The toggle gates both — descriptions call this out and explain the public-CDN safety net.
- All three "what version do we want" branches (env-var pin, experimental pin, experimental cold-start) honor the override and pin the resolved version against feed-latest mutation.

**Private to public CDN fallback chain**
- When an experimental source 404s or DNS-fails AND no usable local copy exists, we transparently retry against the public Azure CDN so the user is never stuck with an empty `~/.azurelogicapps` after enabling the experimental setting.

**User-facing notifications (Phase 6)**
- Every (re)download now runs inside `vscode.window.withProgress` with a context-specific title that names the version and source ("Downloading from public Azure CDN", "Re-downloading because local copy was incomplete", "Experimental source could not deliver, falling back to public Azure CDN", etc.).
- When `verifyLocalBundleHash` reports `sidecarMissing` / `sidecarMismatch` we fire a warning toast immediately before the redownload so the user understands why their cached bundle is being replaced.
- Success toast on completion.

**Tests**
- 66 unit tests in `bundleFeed.test.ts` (was 64 before) cover the env-var pin membership fix, fallback chain, corruption-triggered redownload, and progress notification copy.
- New live E2E phase `bundleintegrityonly` (`bundleCdnHealth.test.ts`) verifies the public CDN actually returns `Content-Length` + `Content-MD5`, that `fetchExpectedMd5` parses it, that `downloadFileWithVerification` succeeds end-to-end, and that the source-URI env override is honored. Wired into `run-e2e.js` as its own mode.
- Full vscode-designer unit suite: 1065 passing. `bundleintegrityonly` E2E: 4/4 passing.

## Notable design choices

- The MD5 sidecar lives next to the bundle (`.bundle-source-md5`) rather than in extension state so a manually-deleted bundle directory self-heals.
- We deliberately do not gate the public-CDN fallback behind a setting; the experimental settings should never leave the user with a broken extension.
- Progress can fire twice in a single activation (private attempt then public fallback). This is intentional so the user sees what's happening.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>