### PR TITLE
fix(vscode): preserve platform so .NET Framework shows in custom-code dropdown

### DIFF
--- a/apps/vs-code-react/src/app/createWorkspace/steps/__test__/dotNetFrameworkStep.test.tsx
+++ b/apps/vs-code-react/src/app/createWorkspace/steps/__test__/dotNetFrameworkStep.test.tsx
@@ -106,9 +106,13 @@ describe('DotNetFrameworkStep', () => {
       renderWithStore({ logicAppType: ProjectType.customCode, platform: 'win32' as any });
       const combobox = screen.getByRole('combobox');
       fireEvent.click(combobox);
+      // Positive Windows case: the dropdown must expose exactly the three correct options.
       expect(screen.getByText('.NET Framework')).toBeInTheDocument();
       expect(screen.getByText('.NET 8')).toBeInTheDocument();
       expect(screen.getByText('.NET 10')).toBeInTheDocument();
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(3);
+      expect(options.map((option) => option.textContent)).toEqual(['.NET Framework', '.NET 8', '.NET 10']);
     });
 
     it('should not render .NET Framework option on non-Windows', () => {
@@ -116,6 +120,28 @@ describe('DotNetFrameworkStep', () => {
       const combobox = screen.getByRole('combobox');
       fireEvent.click(combobox);
       expect(screen.queryByText('.NET Framework')).not.toBeInTheDocument();
+    });
+
+    it('should not render .NET Framework option on Linux', () => {
+      renderWithStore({ logicAppType: ProjectType.customCode, platform: 'linux' as any });
+      const combobox = screen.getByRole('combobox');
+      fireEvent.click(combobox);
+      expect(screen.queryByText('.NET Framework')).not.toBeInTheDocument();
+      expect(screen.getByText('.NET 8')).toBeInTheDocument();
+      expect(screen.getByText('.NET 10')).toBeInTheDocument();
+      const options = screen.getAllByRole('option');
+      expect(options.map((option) => option.textContent)).toEqual(['.NET 8', '.NET 10']);
+    });
+
+    it('should not render .NET Framework option when platform is not yet initialized (null)', () => {
+      renderWithStore({ logicAppType: ProjectType.customCode, platform: null });
+      const combobox = screen.getByRole('combobox');
+      fireEvent.click(combobox);
+      expect(screen.queryByText('.NET Framework')).not.toBeInTheDocument();
+      expect(screen.getByText('.NET 8')).toBeInTheDocument();
+      expect(screen.getByText('.NET 10')).toBeInTheDocument();
+      const options = screen.getAllByRole('option');
+      expect(options.map((option) => option.textContent)).toEqual(['.NET 8', '.NET 10']);
     });
   });
 

--- a/apps/vs-code-react/src/state/__test__/createWorkspaceSlice.test.ts
+++ b/apps/vs-code-react/src/state/__test__/createWorkspaceSlice.test.ts
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { describe, it, expect } from 'vitest';
+import createWorkspaceReducer, {
+  initializeProject,
+  initializeWorkspace,
+  resetState,
+  setCurrentStep,
+  setWorkspaceName,
+  setTargetFramework,
+} from '../createWorkspaceSlice';
+import type { CreateWorkspaceState } from '../createWorkspaceSlice';
+import { Platform } from '@microsoft/vscode-extension-logic-apps';
+
+const getState = (overrides: Partial<CreateWorkspaceState> = {}): CreateWorkspaceState => ({
+  ...(createWorkspaceReducer(undefined, { type: '@@INIT' } as any) as CreateWorkspaceState),
+  ...overrides,
+});
+
+describe('createWorkspaceSlice', () => {
+  describe('initializeWorkspace', () => {
+    it('sets platform, separator, logicAppType and logicAppName from the host payload', () => {
+      const result = createWorkspaceReducer(
+        getState(),
+        initializeWorkspace({
+          platform: Platform.windows,
+          separator: '\\',
+          logicAppType: 'customCode',
+          logicAppName: 'MyLogicApp',
+        })
+      );
+      expect(result.platform).toBe(Platform.windows);
+      expect(result.separator).toBe('\\');
+      expect(result.logicAppType).toBe('customCode');
+      expect(result.logicAppName).toBe('MyLogicApp');
+    });
+  });
+
+  describe('initializeProject', () => {
+    it('sets project fields and captures platform + separator from the host payload', () => {
+      const workspaceFileJson = { folders: [{ name: 'existing' }] };
+      const result = createWorkspaceReducer(
+        getState(),
+        initializeProject({
+          workspaceFileJson,
+          logicAppsWithoutCustomCode: ['app1'],
+          platform: Platform.windows,
+          separator: '\\',
+        })
+      );
+      expect(result.workspaceFileJson).toEqual(workspaceFileJson);
+      expect(result.logicAppsWithoutCustomCode).toEqual(['app1']);
+      // Regression: createProject flow must surface platform so Windows-only .NET Framework appears.
+      expect(result.platform).toBe(Platform.windows);
+      expect(result.separator).toBe('\\');
+    });
+
+    it('leaves platform/separator untouched when the payload omits them', () => {
+      const seeded = getState({ platform: Platform.windows, separator: '\\' });
+      const result = createWorkspaceReducer(seeded, initializeProject({ workspaceFileJson: {}, logicAppsWithoutCustomCode: undefined }));
+      expect(result.platform).toBe(Platform.windows);
+      expect(result.separator).toBe('\\');
+    });
+  });
+
+  describe('resetState', () => {
+    it('preserves platform and separator while clearing form fields when payload is undefined', () => {
+      let state = getState({ platform: Platform.windows, separator: '\\' });
+      state = createWorkspaceReducer(state, setWorkspaceName('MyWorkspace'));
+      state = createWorkspaceReducer(state, setCurrentStep(3));
+      state = createWorkspaceReducer(state, setTargetFramework('net472'));
+
+      const result = createWorkspaceReducer(state, resetState(undefined));
+
+      // Host-environment values survive.
+      expect(result.platform).toBe(Platform.windows);
+      expect(result.separator).toBe('\\');
+      // Form fields are cleared.
+      expect(result.workspaceName).toBe('');
+      expect(result.currentStep).toBe(0);
+      expect(result.targetFramework).toBe('');
+      expect(result.logicAppType).toBe('');
+      expect(result.logicAppName).toBe('');
+    });
+
+    it('preserves platform, separator, logicAppType and logicAppName when preserveLogicAppData is true', () => {
+      const state = getState({
+        platform: Platform.windows,
+        separator: '\\',
+        logicAppType: 'customCode',
+        logicAppName: 'MyLogicApp',
+        workspaceName: 'MyWorkspace',
+      });
+
+      const result = createWorkspaceReducer(state, resetState({ preserveLogicAppData: true }));
+
+      expect(result.platform).toBe(Platform.windows);
+      expect(result.separator).toBe('\\');
+      expect(result.logicAppType).toBe('customCode');
+      expect(result.logicAppName).toBe('MyLogicApp');
+      // Non-preserved form field still cleared.
+      expect(result.workspaceName).toBe('');
+    });
+  });
+
+  describe('platform survives the createWorkspace init -> mount reset sequence', () => {
+    it('keeps platform=win32 after initializeWorkspace followed by resetState(undefined)', () => {
+      let state = getState();
+      // Host initialize_frame.
+      state = createWorkspaceReducer(
+        state,
+        initializeWorkspace({ platform: Platform.windows, separator: '\\', logicAppType: '', logicAppName: '' })
+      );
+      // Flow wrapper mount effect.
+      state = createWorkspaceReducer(state, resetState(undefined));
+
+      expect(state.platform).toBe(Platform.windows);
+    });
+  });
+
+  describe('platform survives the createProject init -> mount reset sequence', () => {
+    it('keeps platform=win32 after initializeProject followed by resetState(undefined)', () => {
+      let state = getState();
+      // Host initialize_frame for the createProject (createLogicApp) flow.
+      state = createWorkspaceReducer(
+        state,
+        initializeProject({
+          workspaceFileJson: {},
+          logicAppsWithoutCustomCode: undefined,
+          platform: Platform.windows,
+          separator: '\\',
+        })
+      );
+      // Flow wrapper mount effect.
+      state = createWorkspaceReducer(state, resetState(undefined));
+
+      expect(state.platform).toBe(Platform.windows);
+    });
+  });
+});

--- a/apps/vs-code-react/src/state/createWorkspaceSlice.ts
+++ b/apps/vs-code-react/src/state/createWorkspaceSlice.ts
@@ -91,10 +91,20 @@ export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseR
   initialState,
   reducers: {
     initializeProject: (state, action: PayloadAction<any>) => {
-      const { workspaceFileJson, logicAppsWithoutCustomCode, existingFolders } = action.payload;
+      const { workspaceFileJson, logicAppsWithoutCustomCode, existingFolders, platform, separator } = action.payload;
       state.workspaceFileJson = workspaceFileJson;
       state.logicAppsWithoutCustomCode = logicAppsWithoutCustomCode;
       state.existingFolders = existingFolders || [];
+      // platform and separator are host-environment values sent by the extension host in the
+      // initialize_frame payload. The createProject (createLogicApp) webview flow only dispatches
+      // initializeProject, so they must be captured here for platform-gated options (e.g. the
+      // Windows-only .NET Framework target framework) to appear.
+      if (platform !== undefined) {
+        state.platform = platform;
+      }
+      if (separator !== undefined) {
+        state.separator = separator;
+      }
     },
     initializeWorkspace: (state, action: PayloadAction<any>) => {
       const { separator, platform, logicAppType, logicAppName, availableProjects } = action.payload;
@@ -207,21 +217,24 @@ export const createWorkspaceSlice = createSlice<CreateWorkspaceState, SliceCaseR
     },
     resetState: (state, action: PayloadAction<{ preserveLogicAppData?: boolean } | undefined>) => {
       const preserveLogicAppData = action.payload?.preserveLogicAppData;
-      const preservedLogicAppType = preserveLogicAppData ? state.logicAppType : '';
-      const preservedLogicAppName = preserveLogicAppData ? state.logicAppName : '';
-      const preservedSeparator = preserveLogicAppData ? state.separator : '/';
-      const preservedPlatform = preserveLogicAppData ? state.platform : null;
-      const preservedAvailableProjects = preserveLogicAppData ? state.availableProjects : [];
+      // Object.assign(state, initialState) overwrites every field with the initial defaults, so any
+      // value we want to keep must be captured here (before the reset) and merged back in the same
+      // call. platform and separator are host-environment values (from initialize_frame), not user
+      // form input, so they must always survive a form reset — otherwise the flow wrappers' mount-time
+      // resetState(undefined) wipes platform to null, hiding the Windows-only .NET Framework option.
+      const preserved: Partial<CreateWorkspaceState> = {
+        platform: state.platform,
+        separator: state.separator,
+        ...(preserveLogicAppData
+          ? {
+              logicAppType: state.logicAppType,
+              logicAppName: state.logicAppName,
+              availableProjects: state.availableProjects,
+            }
+          : {}),
+      };
 
-      Object.assign(state, initialState);
-
-      if (preserveLogicAppData) {
-        state.logicAppType = preservedLogicAppType;
-        state.logicAppName = preservedLogicAppName;
-        state.separator = preservedSeparator;
-        state.platform = preservedPlatform;
-        state.availableProjects = preservedAvailableProjects;
-      }
+      Object.assign(state, initialState, preserved);
     },
     nextStep: (state) => {
       if (state.currentStep < 7) {


### PR DESCRIPTION
## Summary
Fixes the custom-code **.NET Version** dropdown hiding the Windows-only **.NET Framework** (`net472`) option in both the **createWorkspace** and **createProject** VS Code webview wizards. The option is gated on redux `createWorkspace.platform === 'win32'`; on Windows `platform` ended up `null`, so the option disappeared.

## Root cause (two bugs, both in `createWorkspaceSlice.ts`)
- **createWorkspace flow:** `initializeWorkspace` set `platform`, but the flow wrappers' mount-time `resetState(undefined)` wiped it back to `null`.
- **createProject flow:** the webview dispatches only `initializeProject`, which never read `platform`/`separator` from its payload, so `platform` stayed `null`.

The extension host was already correct — it always sends `platform: os.platform()` and `separator` in `initialize_frame` for every create flow.

## Fix
- `resetState` now always preserves the host-environment values `platform` and `separator` (regardless of `preserveLogicAppData`), using a single-merge `Object.assign(state, initialState, preserved)`.
- `initializeProject` now also captures `platform` and `separator` from its payload.

No changes to `webviewCommunication.tsx`, the flow wrappers, or the host handler — the createProject and createWorkspace flows are kept separate.

## Tests
- **New** `state/__test__/createWorkspaceSlice.test.ts` — reducer tests locking preservation behavior + positive Windows sequences for both flows.
- **Strengthened** `dotNetFrameworkStep.test.tsx` — asserts the exact per-platform option set (`win32` → Framework/8/10; darwin/linux/null → 8/10).

All 24 tests pass locally; biome clean.

## Notes
This is the `hotfix/v5.970` variant of the same fix landing in `hotfix/v5.961` (#16) and `main` (#17), adapted for the diverged 970 state shape (`availableProjects`/`existingFolders` preserved).
